### PR TITLE
fix: repo interop

### DIFF
--- a/test/repo.js
+++ b/test/repo.js
@@ -80,7 +80,7 @@ describe.skip('repo', () => {
   })
 
   it('read repo: js -> go', function (done) {
-    this.timeout(50 * 1000)
+    this.timeout(80 * 1000)
     const dir = path.join(os.tmpdir(), hat())
     const data = crypto.randomBytes(1024 * 5)
 
@@ -91,26 +91,34 @@ describe.skip('repo', () => {
     series([
       (cb) => jsDf.spawn({
         repoPath: dir,
+        disposable: false,
         initOptions: { bits: 512 }
-      }, cb),
-      (node, cb) => {
+      }, (err, node) => {
+        expect(err).to.not.exist()
+
         jsDaemon = node
-        cb()
-      },
-      (cb) => jsDaemon.api.add(data, cb),
-      (res, cb) => {
+        jsDaemon.init(cb)
+      }),
+      (cb) => jsDaemon.start(cb),
+
+      (cb) => jsDaemon.api.add(data, (err, res) => {
+        expect(err).to.not.exist()
+
         hash = res[0].hash
         catAndCheck(jsDaemon.api, hash, data, cb)
-      },
+      }),
       (cb) => jsDaemon.stop(cb),
       (cb) => goDf.spawn({
         repoPath: dir,
+        disposable: false,
         initOptions: { bits: 1024 }
-      }, cb),
-      (node, cb) => {
+      }, (err, node) => {
+        expect(err).to.not.exist()
+
         goDaemon = node
         cb()
-      },
+      }),
+      (cb) => goDaemon.start(cb),
       (cb) => catAndCheck(goDaemon.api, hash, data, cb),
       (cb) => goDaemon.stop(cb)
     ], done)

--- a/test/repo.js
+++ b/test/repo.js
@@ -26,10 +26,7 @@ function catAndCheck (api, hash, data, callback) {
   })
 }
 
-// The repo was again changed on go-ipfs 0.4.16
-// TODO: create spec tests for repo
-describe.skip('repo', () => {
-  // skipping until https://github.com/ipfs/interop/issues/8 is addressed
+describe('repo', () => {
   if (isWindows) {
     return
   }


### PR DESCRIPTION
When the `js-ipfs-repo` adds the `datastore_spec` file, as well as the `datastore` property to the config, the repo's will be interoperable again 🚀 

Tested with both PR's needed:

- [x] [js-ipfs#1461](https://github.com/ipfs/js-ipfs/pull/1496)
- [x] [js-ipfs-repo#173](https://github.com/ipfs/js-ipfs-repo/pull/173)