### PR TITLE
test: turn off discovery to make tests run faster

### DIFF
--- a/test/utils/daemon.js
+++ b/test/utils/daemon.js
@@ -10,7 +10,18 @@ const spawnInitAndStartDaemon = (factory) => {
       initOptions: {
         bits: 1024
       },
-      config: { Bootstrap: [] }
+      config: {
+        Bootstrap: [],
+        Discovery: {
+          MDNS: {
+            Enabled: false
+          },
+          webRTCStar: {
+            Enabled: false
+          }
+        }
+      },
+      profile: 'test'
     }, (error, instance) => {
       if (error) {
         return reject(error)


### PR DESCRIPTION
Similar to ipfs/js-ipfs-http-client#942 - in my testing using the `test` profile for go and turning off mdns/webrtcstar decreases the time it takes to run the files tests (at least) from 15-45s to 7s