### PR TITLE
fix: ipns use offline on daemon start

### DIFF
--- a/test/ipns.js
+++ b/test/ipns.js
@@ -18,8 +18,7 @@ const spawnJsDaemon = (dir, callback) => {
     .spawn({
       repoPath: dir,
       disposable: false,
-      initOptions: { bits: 512 },
-      args: ['--offline']
+      initOptions: { bits: 512 }
     }, callback)
 }
 
@@ -28,8 +27,7 @@ const spawnGoDaemon = (dir, callback) => {
     .spawn({
       repoPath: dir,
       disposable: false,
-      initOptions: { bits: 1024 },
-      args: ['--offline']
+      initOptions: { bits: 1024 }
     }, callback)
 }
 
@@ -49,7 +47,7 @@ const publishAndResolve = (publisherDaemon, resolverDaemon, callback) => {
     series([
       (cb) => publisherDaemon.stop(cb),
       (cb) => setTimeout(cb, 2000),
-      (cb) => resolverDaemon.start(cb)
+      (cb) => resolverDaemon.start(['--offline'], cb)
     ], callback)
   }
 


### PR DESCRIPTION
In the context of [ipfs/interop#60#issuecomment-482152895](https://github.com/ipfs/interop/pull/60#issuecomment-482152895), the `offline` flag should be provided through the daemon `start`, as this is is not a disposable daemon. Only non disposable daemons start can start automatically with the `args` provided in `spawn`.