### PR TITLE
chore: disable firefox ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,5 @@ jobs:
         chrome: stable
       script: npx aegir test -t browser
 
-    - stage: test
-      name: firefox
-      addons:
-        firefox: latest
-      script: npx aegir test -t browser -- --browsers FirefoxHeadless
-
 notifications:
   email: false


### PR DESCRIPTION
We currently have some inconsistencies in the circuit relay tests between chrome and firefox tests. This way, we will disable the firefox job and track it in a new issue-
