### PR TITLE
fix: enable browser-browser-go circuit test

### DIFF
--- a/test/circuit/browser.js
+++ b/test/circuit/browser.js
@@ -130,8 +130,7 @@ module.exports = {
         (cb) => setTimeout(cb, 5000),
         (cb) => nodeA.ipfsd.api.swarm.connect(getCircuitAddr(nodeB.addrs), cb)
       ], callback)
-    },
-    skip: () => true
+    }
   },
   'browser-browser-js': {
     create: (callback) => series([

--- a/test/ipns.js
+++ b/test/ipns.js
@@ -53,13 +53,13 @@ const publishAndResolve = (publisherDaemon, resolverDaemon, callback) => {
 
   series([
     (cb) => publisherDaemon.init(cb),
-    (cb) => publisherDaemon.start(cb),
+    (cb) => publisherDaemon.start(['--offline'], cb),
     (cb) => publisherDaemon.api.id((err, res) => {
       expect(err).to.not.exist()
       nodeId = res.id
       cb()
     }),
-    (cb) => publisherDaemon.api.name.publish(ipfsRef, { resolve: false }, cb),
+    (cb) => publisherDaemon.api.name.publish(ipfsRef, { resolve: false, 'allow-offline': true }, cb),
     (cb) => sameDaemon ? cb() : stopPublisherAndStartResolverDaemon(cb),
     (cb) => {
       resolverDaemon.api.name.resolve(nodeId, { local: true }, (err, res) => {


### PR DESCRIPTION
This reenables the `browser-browser-go` circuit test which is working.

fixes https://github.com/ipfs/interop/issues/16