### PR TITLE
chore: update js-ipfs to 0.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "form-data": "^2.3.3",
     "go-ipfs-dep": "~0.4.20",
     "hat": "0.0.3",
-    "ipfs": "github:ipfs/js-ipfs#update-ipld-formats-async-await-mfs-and-unixfs-and-base32-cids",
+    "ipfs": "~0.36.0-rc.0",
     "ipfs-http-client": "^30.1.1",
     "ipfs-repo": "~0.26.1",
     "ipfs-unixfs": "~0.1.16",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "form-data": "^2.3.3",
     "go-ipfs-dep": "~0.4.20",
     "hat": "0.0.3",
-    "ipfs": "~0.36.0-rc.0",
+    "ipfs": "~0.36.0",
     "ipfs-http-client": "^30.1.1",
     "ipfs-repo": "~0.26.1",
     "ipfs-unixfs": "~0.1.16",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "form-data": "^2.3.3",
     "go-ipfs-dep": "~0.4.20",
     "hat": "0.0.3",
-    "ipfs": "~0.35.0",
+    "ipfs": "github:ipfs/js-ipfs#update-ipld-formats-async-await-mfs-and-unixfs-and-base32-cids",
     "ipfs-http-client": "^30.1.1",
     "ipfs-repo": "~0.26.1",
     "ipfs-unixfs": "~0.1.16",


### PR DESCRIPTION
Tests passing for me locally except for the following, which will only pass once `0.4.21` is released:

```
  125 passing (18m)
  6 pending
  2 failing

  1) files
       has the same hashes for
         small files with CIDv1:

      AssertionError: expected 'zb2rhiNedvrkpYhcrgtpmhKk5UPzcgizgSXaQLYXNY745BmYP' to deeply equal 'bafkreifojmzibzlof6xyh5auu3r5vpu5l67brf3fitaf73isdlglqw2t7q'
      + expected - actual

      -zb2rhiNedvrkpYhcrgtpmhKk5UPzcgizgSXaQLYXNY745BmYP
      +bafkreifojmzibzlof6xyh5auu3r5vpu5l67brf3fitaf73isdlglqw2t7q
      
      at results.forEach.res (test/files.js:66:50)
      at Array.forEach (<anonymous>)
      at Promise.all.then.results (test/files.js:66:15)
      at processTicksAndRejections (internal/process/task_queues.js:86:5)

  2) files
       has the same hashes for
         big files with CIDv1:

      AssertionError: expected 'zdj7WdLGvbMkLYcKVjbP9yVuDHD2qg93HCoLjRXkTztQQpkLP' to deeply equal 'bafybeidvns3c4jircsjoju36de643iuikdpq7oyieanmvwh5lyeahj3j3a'
      + expected - actual

      -zdj7WdLGvbMkLYcKVjbP9yVuDHD2qg93HCoLjRXkTztQQpkLP
      +bafybeidvns3c4jircsjoju36de643iuikdpq7oyieanmvwh5lyeahj3j3a
      
      at results.forEach.res (test/files.js:66:50)
      at Array.forEach (<anonymous>)
      at Promise.all.then.results (test/files.js:66:15)
      at processTicksAndRejections (internal/process/task_queues.js:86:5)
```