### PR TITLE
test: disable mdns in exchange files

### DIFF
--- a/test/exchange-files.js
+++ b/test/exchange-files.js
@@ -100,11 +100,38 @@ const min = 60 * 1000
 const timeout = isCi ? 8 * min : 5 * min
 
 function createJs (cb) {
-  jsDf.spawn({ type: 'js', initOptions: { bits: 512 }, config: { Bootstrap: [] } }, cb)
+  jsDf.spawn({
+    type: 'js',
+    initOptions: { bits: 512 },
+    config: {
+      Bootstrap: [],
+      Discovery: {
+        MDNS: {
+          Enabled: false
+        },
+        webRTCStar: {
+          Enabled: false
+        }
+      }
+    }
+  }, cb)
 }
 
 function createGo (cb) {
-  goDf.spawn({ initOptions: { bits: 1024 }, config: { Bootstrap: [] } }, cb)
+  goDf.spawn({
+    initOptions: { bits: 1024 },
+    config: {
+      Bootstrap: [],
+      Discovery: {
+        MDNS: {
+          Enabled: false
+        },
+        webRTCStar: {
+          Enabled: false
+        }
+      }
+    }
+  }, cb)
 }
 
 describe('exchange files', () => {

--- a/test/exchange-files.js
+++ b/test/exchange-files.js
@@ -108,9 +108,6 @@ function createJs (cb) {
       Discovery: {
         MDNS: {
           Enabled: false
-        },
-        webRTCStar: {
-          Enabled: false
         }
       }
     }
@@ -124,9 +121,6 @@ function createGo (cb) {
       Bootstrap: [],
       Discovery: {
         MDNS: {
-          Enabled: false
-        },
-        webRTCStar: {
           Enabled: false
         }
       }


### PR DESCRIPTION
The tests are failing against the latest go-ipfs rc candidate (0.4.21-rc.3), https://github.com/ipfs/go-ipfs/issues/6389. This is due to an issue with go announcing its address over MDNS with port 4001 even though the port is actually different. Since the MDNS discovery occurs before dial in the test and fails, the connect attempt will subsequently fail due to JS doing a blacklisting backoff on failed connection attempts. 

While this doesn't solve the underlying issue, we shouldn't have MDNS turned on for these tests. My recommendation is:
> I'd recommend we disable MDNS in the tests for now and file an issue for fixing MDNS so this isn't blocking the release as it's not really a critical issue. In reality we should just move to the new MDNS spec for both implementations and not waste time on a fix for this. The default ipfs daemon runs on port 4001 so this shouldn't be an issue in most cases, and the interop fix was a recent update for js.