### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ipfs-http-client": "^32.0.0",
     "ipfs-repo": "~0.26.6",
     "ipfs-unixfs": "~0.1.16",
-    "ipfsd-ctl": "~0.42.2",
+    "ipfsd-ctl": "~0.42.4",
     "ipns": "~0.5.1",
     "is-ci": "^2.0.0",
     "left-pad": "^1.3.0",

--- a/test/files.js
+++ b/test/files.js
@@ -23,14 +23,14 @@ class ExpectedError extends Error {
 function checkNodeTypes (daemon, file) {
   return daemon.api.object.get(file.hash)
     .then(node => {
-      const meta = UnixFs.unmarshal(node.data)
+      const meta = UnixFs.unmarshal(node.Data)
 
       expect(meta.type).to.equal('file')
-      expect(node.links.length).to.equal(2)
+      expect(node.Links.length).to.equal(2)
 
       return Promise.all(
-        node.links.map(link => daemon.api.object.get(link.toJSON().cid).then(child => {
-          const childMeta = UnixFs.unmarshal(child.data)
+        node.Links.map(link => daemon.api.object.get(link.Hash).then(child => {
+          const childMeta = UnixFs.unmarshal(child.Data)
 
           expect(childMeta.type).to.equal('raw')
         }))
@@ -379,7 +379,7 @@ describe('files', function () {
         await daemon.api.files.cp(`/ipfs/${hash}`, dir)
 
         const node = await daemon.api.object.get(hash)
-        const meta = UnixFs.unmarshal(node.data)
+        const meta = UnixFs.unmarshal(node.Data)
 
         expect(meta.type).to.equal('hamt-sharded-directory')
 
@@ -402,7 +402,7 @@ describe('files', function () {
 
         const stats = await daemon.api.files.stat(dir)
         const nodeAfterUpdates = await daemon.api.object.get(stats.hash)
-        const metaAfterUpdates = UnixFs.unmarshal(nodeAfterUpdates.data)
+        const metaAfterUpdates = UnixFs.unmarshal(nodeAfterUpdates.Data)
 
         expect(metaAfterUpdates.type).to.equal('hamt-sharded-directory')
 

--- a/test/node.js
+++ b/test/node.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+require('./ipns-pubsub')
 require('./cid-version-agnostic')
 require('./pubsub')
 require('./circuit')
@@ -10,4 +11,3 @@ require('./ipns')
 require('./kad-dht')
 require('./pin')
 require('./files')
-require('./ipns-pubsub')


### PR DESCRIPTION
This PR addresses [ipfs/interop#71](https://github.com/ipfs/interop/issues/71). IPNS Pubsub tests were failing on master for linux, as a result of `cids` being outdated on `ipfsd-ctl`