### PR TITLE
fix: interop dial blacklist

### DIFF
--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -23,6 +23,14 @@ const config = {
     API: '/ip4/0.0.0.0/tcp/0',
     Gateway: '/ip4/0.0.0.0/tcp/0',
     Swarm: []
+  },
+  Discovery: {
+    MDNS: {
+      Enabled: false
+    },
+    webRTCStar: {
+      Enabled: false
+    }
   }
 }
 
@@ -33,7 +41,10 @@ const spawnJsDaemon = (callback) => {
     .spawn({
       disposable: true,
       args: ['--enable-namesys-pubsub'], // enable ipns over pubsub
-      config
+      config: {
+        ...config,
+        Bootstrap: []
+      }
     }, callback)
 }
 


### PR DESCRIPTION
We introduced a dial queue on js-libp2p-switch, which intends to (among other factors) blacklist abusive peers. In this test, and differently, to the interop tests for pubsub, we had the default bootstrap list, as well as MDNS discovery enabled. This way, we were discovering the peer in several ways and trying to dial to it, while also dialing explicitly to it, in order to guarantee that each peer knows each other before the IPNS over pubsub tests. 
With this into account, the libp2p-switch was marking the peer as blacklisted and we were not being able to dial with it.

I created this PR, which basically has an empty bootstrap list for the js node, and disables MDNS. This way, we will have the CI green in here and test the interop over the wire. Moreover, I will create an issue in js-libp2p-switch so that we rethink the way we blacklist nodes next week, once @jacobheun is back

More context: [ipfs/interop#71#issuecomment-511833421](https://github.com/ipfs/interop/issues/71#issuecomment-511833421)