### PR TITLE
fix: fix up pubsub tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "interop-ipfs",
+  "name": "ipfs-interop",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1424,12 +1424,19 @@
       }
     },
     "@hapi/accept": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.2.tgz",
-      "integrity": "sha512-UtXlTT59srtMr7ZRBzK2CvyWqFwlf78hPt9jEXqkwfbwiwRH1PRv/qkS8lgr5ZyoG6kfpU3xTgt2X91Yfe/6Yg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
+      "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/address": {
@@ -1438,27 +1445,48 @@
       "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
     },
     "@hapi/ammo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
-      "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.1.tgz",
+      "integrity": "sha512-NYFK27VSPGyQ/KmOQedpQH4PSjE7awLntepX68vrYtRvuJO21W1kX0bK2p3C+6ltUwtCQSvmNT8a4uMVAysC6Q==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/b64": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.0.tgz",
-      "integrity": "sha512-hmfPC1aF7cP21489A/IWPC3s1GE+1eAteVwFcOWLwj0Pky8eHgvrXPSSko2IeCpxqOdZhYw71IFN8xKPdv3CtQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/boom": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.2.tgz",
-      "integrity": "sha512-T2CYcTI0AqSvC6YC7keu/fh9LVSMzfoMLharBnPbOwmc+Cexj9joIc5yNDKunaxYq9LPuOwMS0f2B3S1tFQUNw==",
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+      "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/bounce": {
@@ -1471,9 +1499,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
         }
       }
     },
@@ -1483,32 +1511,78 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/call": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.0.tgz",
-      "integrity": "sha512-CiVEXjD/jiIHBqufBW3pdedshEMjRmHtff7m1puot8j4MUmuKRbLlh0DB8fv6QqH/7/55pH1qgFj300r0WpyMw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.1.tgz",
+      "integrity": "sha512-M6fC+9+K/ZB4hIdVQ8i0kc/6J5PWlW3PEWYKAAZpw0sk+28LiRTSF8BjOWwmiIjZWWs42AnEIiFJA0YrvcDnlw==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/catbox": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.1.tgz",
-      "integrity": "sha512-u13BXlnmmrNUZssjTriRVTLuk6I/yUy5C1/Pia1+E2cpfd7o2/jmEvYdFgeS0Ft9QTz7WWhpXKlrguARUuohhQ==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
+      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x",
         "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+          "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+        },
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        },
+        "@hapi/topo": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.5.tgz",
+          "integrity": "sha512-bi9m1jrui9LlvtVdLaHv0DqeOoe+I8dep+nEcTgW6XxJHL3xArQcilYz3tIp0cRC4gWlsVtABK7vNKg4jzEmAA==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/catbox-memory": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.0.tgz",
-      "integrity": "sha512-libCGyufOZaJu6uE9nVXw/u8tqOt4ifNIrOSAsDjzS+af3vPJyid8faOICqKCAh3E338UAsUe5AeYdezdsmtpg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
+      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/content": {
@@ -1520,9 +1594,9 @@
       }
     },
     "@hapi/cryptiles": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
-      "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
+      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
       "requires": {
         "@hapi/boom": "7.x.x"
       }
@@ -1532,10 +1606,15 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
       "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
     },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
     "@hapi/hapi": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.1.tgz",
-      "integrity": "sha512-gBiU9isWWezrg0ucX95Ph6AY6fUKZub3FxKapaleoFBJDOUcxTYiQR6Lha2zvHalIFoTl3K04O3Yr/5pD17QkQ==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.0.tgz",
+      "integrity": "sha512-uk9zqknRLcNVQKgrPURm85DqkdroWP8eDRekh/IPoKvC4VjdZSn6EH2eUriOwyud/CldeBS3HDIJ/PtRj3VxDQ==",
       "requires": {
         "@hapi/accept": "3.x.x",
         "@hapi/ammo": "3.x.x",
@@ -1545,7 +1624,7 @@
         "@hapi/catbox": "10.x.x",
         "@hapi/catbox-memory": "4.x.x",
         "@hapi/heavy": "6.x.x",
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/joi": "15.x.x",
         "@hapi/mimos": "4.x.x",
         "@hapi/podium": "3.x.x",
@@ -1555,16 +1634,55 @@
         "@hapi/subtext": "6.x.x",
         "@hapi/teamwork": "3.x.x",
         "@hapi/topo": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/heavy": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.0.tgz",
-      "integrity": "sha512-tzGU9cElY0IxRBudGB7tLFkdpBD8XQPfd6G7DSOnvHRK+q96UHGHn4t59Yd7kDpVucNkErWWYarsGx2KmKPkXA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
+      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+          "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+        },
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        },
+        "@hapi/topo": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.5.tgz",
+          "integrity": "sha512-bi9m1jrui9LlvtVdLaHv0DqeOoe+I8dep+nEcTgW6XxJHL3xArQcilYz3tIp0cRC4gWlsVtABK7vNKg4jzEmAA==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/hoek": {
@@ -1573,34 +1691,67 @@
       "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
     },
     "@hapi/inert": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.1.tgz",
-      "integrity": "sha512-kovx94LVcT9jELc+k4xuR+1lsdmimjHKn9SpI/YAXDioO7m4YzksEBSmneH3ZwVWVnl2j66Sfzvs2IweHRxyNA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.2.tgz",
+      "integrity": "sha512-8IaGfAEF8SwZtpdaTq0G3aDPG35ZTfWKjnMNniG2N3kE+qioMsBuImIGxna8TNQ+sYMXYK78aqmvzbQHno8qSQ==",
       "requires": {
         "@hapi/ammo": "3.x.x",
         "@hapi/boom": "7.x.x",
         "@hapi/bounce": "1.x.x",
         "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x",
+        "@hapi/joi": "16.x.x",
         "lru-cache": "4.1.x"
       },
       "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+          "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+        },
         "@hapi/hoek": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        },
+        "@hapi/topo": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.5.tgz",
+          "integrity": "sha512-bi9m1jrui9LlvtVdLaHv0DqeOoe+I8dep+nEcTgW6XxJHL3xArQcilYz3tIp0cRC4gWlsVtABK7vNKg4jzEmAA==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
         }
       }
     },
     "@hapi/iron": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.0.tgz",
-      "integrity": "sha512-+MK3tBPkEKd50SrDTRXa2DVvE0UTPFKxGbodlbQpNP9SVlxi+ZwA640VJtMNj84FZh81UUxda8AOLPRKFffnEA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
+      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
       "requires": {
         "@hapi/b64": "4.x.x",
         "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
         "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/joi": {
@@ -1620,80 +1771,209 @@
       "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
     },
     "@hapi/mimos": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.0.tgz",
-      "integrity": "sha512-CkxOB15TFZDMl5tQ5qezKZvvBnkRYVc8YksNfA5TnqQMMsU7vGPyvuuNFqj+15bfEwHyM6qasxyQNdkX9B/cQw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
+      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "mime-db": "1.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/nigel": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.0.tgz",
-      "integrity": "sha512-IJyau32pz5Bf7pzUU/8AIn/SvPvhLMQcOel6kM7ECpKyPc895AwttSusRKfgTwfxZOEG6W8DnNv25gLtqrVFSg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
+      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/vise": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/pez": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.0.tgz",
-      "integrity": "sha512-c+AxL8/cCj+7FB+tzJ5FhWKYP8zF7/7mA3Ft3a5y7h6YT26qzhj5d2JY27jur30KaZbrZAd4ofXXkqvE/IpJlA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
+      "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
       "requires": {
         "@hapi/b64": "4.x.x",
         "@hapi/boom": "7.x.x",
         "@hapi/content": "4.x.x",
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/nigel": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
     "@hapi/podium": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.0.tgz",
-      "integrity": "sha512-IwyewAPGlCoq+g5536PKSDqSTfgpwbj+q4cBJpEUNqzwc5C5SM2stuFsULU7x1jKeWevfgWDoYWC75ML4IOYug==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.2.tgz",
+      "integrity": "sha512-g9zlAkRL2uDlnEo64xzEhFLblf4fdL5Z6evAO0wJhdxEvokI/+6ryv7k6uhND481LiLzQz8qTtPYMuhH1hichw==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+          "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+        },
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        },
+        "@hapi/topo": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.5.tgz",
+          "integrity": "sha512-bi9m1jrui9LlvtVdLaHv0DqeOoe+I8dep+nEcTgW6XxJHL3xArQcilYz3tIp0cRC4gWlsVtABK7vNKg4jzEmAA==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/shot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.0.tgz",
-      "integrity": "sha512-rpUU5cF08fqAZLLnue6Sy0osj1QMPbrYskehxtLFPdk7CwlPcu9N/wRtgu7vDHTQCKTkag6M8sjc8V8p8lSxpg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
+      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+          "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+        },
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        },
+        "@hapi/topo": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.5.tgz",
+          "integrity": "sha512-bi9m1jrui9LlvtVdLaHv0DqeOoe+I8dep+nEcTgW6XxJHL3xArQcilYz3tIp0cRC4gWlsVtABK7vNKg4jzEmAA==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/somever": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.0.tgz",
-      "integrity": "sha512-kMPewbpgLd0MSlNg0bjvq57Levozbg7c3O0idpWRxRgXfXBALNATLf8GRVbnMehYXAh7YRD2mR/91kginDtJ2Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
+      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
       "requires": {
         "@hapi/bounce": "1.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/statehood": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.0.tgz",
-      "integrity": "sha512-qc8Qq3kg0b3XK7siXf6DK0wp+rcOrXv336kIP6YrtD9TbQ45TsBobwKkUXB+4R3GCCQ8a6tOj8FR/9bdtjKJCA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
+      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bounce": "1.x.x",
         "@hapi/bourne": "1.x.x",
         "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/iron": "5.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+          "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+        },
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        },
+        "@hapi/topo": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.5.tgz",
+          "integrity": "sha512-bi9m1jrui9LlvtVdLaHv0DqeOoe+I8dep+nEcTgW6XxJHL3xArQcilYz3tIp0cRC4gWlsVtABK7vNKg4jzEmAA==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.1.tgz",
-      "integrity": "sha512-Y7NjKFRPwlzKRw5IdwRou42hR4IBQZolT+/DlvfSr/CBjGyu38n5+9LKfNKzqB/0AVEk+xynCijsx1o1UVWX8A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.2.tgz",
+      "integrity": "sha512-G1kqD1E2QdxpvpL26WieIyo3z0qCa/sAGSa2TJI/PYPWCR9rL0rqFvhWY774xPZ4uK1PV3TIaJcx8AruAvxclg==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
@@ -1705,9 +1985,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
         }
       }
     },
@@ -1732,21 +2012,35 @@
       }
     },
     "@hapi/vise": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.0.tgz",
-      "integrity": "sha512-DUDzV0D4iVO5atghsjGZtzaF0HVtRLcxcnH6rAONyH0stnoLiFloGEuP5nkbIPU0B9cgWTzTUsQPuNHBzxy9Yw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
+      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@hapi/wreck": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.1.tgz",
-      "integrity": "sha512-ByXQna/W1FZk7dg8NEhL79u4QkhzszRz76VpgyGstSH8bLM01a0C8RsxmUBgi6Tjkag5jA9kaEIhF9dLpMrtBw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
+      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "@marionebl/sander": {
@@ -1808,6 +2102,45 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -2642,6 +2975,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+    },
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -3130,9 +3468,9 @@
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "bip174": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-1.0.0.tgz",
-      "integrity": "sha512-AaoWrkYtv6A2y8H+qzs6NvRWypzNbADT8PQGpM9rnP+jLzeol+uzhe3Myeuq/dwrHYtmsW8V71HmX2oXhQGagw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-1.0.1.tgz",
+      "integrity": "sha512-Mq2aFs1TdMfxBpYPg7uzjhsiXbAtoVq44TNjEWtvuZBiBgc3m7+n55orYMtTAxdg7jWbL4DtH0MKocJER4xERQ=="
     },
     "bip32": {
       "version": "2.0.4",
@@ -3169,13 +3507,13 @@
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "bitcoinjs-lib": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.2.tgz",
-      "integrity": "sha512-Qa1TY8xaFRaLPD2YunfQX1vhHAh0387SJ/Zu7lNSRyzpg8lDru8gv+w6pqxOkcdj4dm4Fn1JmWb0m8Oy+8TfiA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.6.tgz",
+      "integrity": "sha512-NgvnA8XXUuzpuBnVs1plzZvVOYsuont4KPzaGcVIwjktYQbCk1hUkXnt4wujIOBscNsXuu+plVbPYvtMosZI/w==",
       "requires": {
         "@types/node": "10.12.18",
         "bech32": "^1.1.2",
-        "bip174": "^1.0.0",
+        "bip174": "^1.0.1",
         "bip32": "^2.0.4",
         "bip66": "^1.1.0",
         "bitcoin-ops": "^1.4.0",
@@ -3567,9 +3905,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz",
-      "integrity": "sha1-7Q82t64WamanzRdMBGeuje3wCPU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "buffer-peek-stream": {
       "version": "1.0.1",
@@ -3592,6 +3930,13 @@
       "integrity": "sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=",
       "requires": {
         "buffer-indexof": "~0.0.0"
+      },
+      "dependencies": {
+        "buffer-indexof": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz",
+          "integrity": "sha1-7Q82t64WamanzRdMBGeuje3wCPU="
+        }
       }
     },
     "buffer-xor": {
@@ -5396,6 +5741,11 @@
         "rimraf": "^2.6.3"
       }
     },
+    "delay": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
+      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5569,14 +5919,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw="
-    },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
     },
     "diff": {
       "version": "4.0.1",
@@ -6969,9 +7311,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.0.tgz",
-      "integrity": "sha512-/jdFHyHOIS3FiAnunwRZ+oNulFtNNSHyWii3PaNHReOUmBAxij7KMyZLKh0tE16JEsJtXOVz1ceYuq++ILzv+g=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.2.tgz",
+      "integrity": "sha512-GkltYRIqBLzaZLmF/K3E+g9lZ4O4FL+TtpisAlD3N+UVlR+mrtoG+TvxavqVa6PwOY4nKIEMe5pl6MrTio3Lww=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -7292,6 +7634,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+    },
     "fast-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
@@ -7353,11 +7700,6 @@
         }
       }
     },
-    "fast-json-parse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -7369,14 +7711,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-redact": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.5.0.tgz",
-      "integrity": "sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fast-write-atomic": {
       "version": "0.2.1",
@@ -7429,9 +7771,9 @@
       }
     },
     "file-type": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.1.0.tgz",
-      "integrity": "sha512-aZkf42yWGiH+vSOpbVgvbnoRuX4JiitMX9pHYqTHemNQ3lrx64iHi33YGAP7TSJSno56kxQY1lHmw8S6ujlFUg=="
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.3.0.tgz",
+      "integrity": "sha512-4E4Esq9KLwjYCY32E7qSmd0h7LefcniZHX+XcdJ4Wfx1uGJX7QCigiqw/U0yT7WOslm28yhxl87DJ0wHYv0RAA=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -7611,6 +7953,14 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -9410,6 +9760,16 @@
       "resolved": "https://registry.npmjs.org/globals-docs/-/globals-docs-2.4.0.tgz",
       "integrity": "sha512-B69mWcqCmT3jNYmSxRxxOXWfzu3Go8NQXPfl2o0qPd1EEFhwW0dFUg9ztTu915zPQzqwIhWAlw6hmfIcCK4kkQ=="
     },
+    "globalthis": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.0.tgz",
+      "integrity": "sha512-vcCAZTJ3r5Qcu5l8/2oyVdoFwxKgfYnMTR2vwWeux/NAVZK3PwcMaWkdUIn4GJbmKuRK7xcvDsLuK+CKcXyodg==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "object-keys": "^1.0.12"
+      }
+    },
     "globby": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
@@ -9670,14 +10030,21 @@
       }
     },
     "hapi-pino": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.0.2.tgz",
-      "integrity": "sha512-n2atjPT0waN8vmGqQSn68Au8lyJmaalLK3ucu+QWOZaBDm4l3N9lo8u8kaaN1x5Oz04k1kZTOnM4bgn0oZb7Og==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.1.0.tgz",
+      "integrity": "sha512-LP/hfRj2WCWg8QRjPt+FZzhnnDP+h28NkdLlNn0RbtAHp28ZynqHzF3hxjl+mJdl8mwo2L4DOw91uMsi+6V7Qg==",
       "requires": {
-        "@hapi/hoek": "^6.2.4",
+        "@hapi/hoek": "^8.2.2",
         "abstract-logging": "^1.0.0",
-        "pino": "^5.13.1",
-        "pino-pretty": "^2.6.1"
+        "pino": "^5.13.2",
+        "pino-pretty": "^3.2.1"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+          "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+        }
       }
     },
     "har-schema": {
@@ -10407,18 +10774,18 @@
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "ipfs": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.37.0.tgz",
-      "integrity": "sha512-nZb/qMmq3G1IswN2g2DL9u/mdRMND5WvgChmcDiq4Z0zyntLTaCMgwnXDAnCwhXyMLanY8AlGh42nq+DQoc51A==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.38.0.tgz",
+      "integrity": "sha512-Yt4bTEqJ32zml6FbTIaEUZS4Wo8MI97Q/fqU3TgbflKln5YEY7nXcr4Y/fzC/2n6jZG7j7XZsP0LFM557WJ+Fw==",
       "requires": {
-        "@hapi/ammo": "^3.1.0",
-        "@hapi/boom": "^7.4.2",
-        "@hapi/hapi": "^18.3.1",
+        "@hapi/ammo": "^3.1.1",
+        "@hapi/boom": "^7.4.3",
+        "@hapi/hapi": "^18.3.2",
         "@hapi/joi": "^15.0.1",
         "array-shuffle": "^1.0.1",
         "async": "^2.6.1",
         "async-iterator-all": "^1.0.0",
-        "async-iterator-to-pull-stream": "^1.1.0",
+        "async-iterator-to-pull-stream": "^1.3.0",
         "async-iterator-to-stream": "^1.1.0",
         "base32.js": "~0.1.0",
         "bignumber.js": "^9.0.0",
@@ -10427,7 +10794,6 @@
         "bs58": "^4.0.1",
         "buffer-peek-stream": "^1.0.1",
         "byteman": "^1.3.5",
-        "callbackify": "^1.1.0",
         "cid-tool": "~0.3.0",
         "cids": "~0.7.1",
         "class-is": "^1.1.0",
@@ -10436,27 +10802,28 @@
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
+        "explain-error": "^1.0.4",
         "file-type": "^12.0.1",
         "fnv1a": "^1.0.1",
         "fsm-event": "^2.1.0",
         "get-folder-size": "^2.0.0",
         "glob": "^7.1.3",
-        "hapi-pino": "^6.0.0",
+        "hapi-pino": "^6.1.0",
         "hashlru": "^2.3.0",
         "human-to-milliseconds": "^2.0.0",
         "interface-datastore": "~0.6.0",
         "ipfs-bitswap": "~0.25.1",
         "ipfs-block": "~0.8.1",
         "ipfs-block-service": "~0.15.2",
-        "ipfs-http-client": "^33.1.0",
+        "ipfs-http-client": "^37.0.1",
         "ipfs-http-response": "~0.3.1",
-        "ipfs-mfs": "~0.12.0",
-        "ipfs-multipart": "~0.1.1",
+        "ipfs-mfs": "^0.12.2",
+        "ipfs-multipart": "^0.2.0",
         "ipfs-repo": "~0.26.6",
         "ipfs-unixfs": "~0.1.16",
         "ipfs-unixfs-exporter": "~0.37.7",
         "ipfs-unixfs-importer": "~0.39.11",
-        "ipfs-utils": "~0.0.4",
+        "ipfs-utils": "^0.3.0",
         "ipld": "~0.24.1",
         "ipld-bitcoin": "~0.3.0",
         "ipld-dag-cbor": "~0.15.0",
@@ -10471,30 +10838,34 @@
         "is-pull-stream": "~0.0.0",
         "is-stream": "^2.0.0",
         "iso-url": "~0.4.6",
-        "just-flatten-it": "^2.1.0",
+        "it-pipe": "^1.0.1",
+        "it-to-stream": "^0.1.1",
         "just-safe-set": "^2.1.0",
         "kind-of": "^6.0.2",
-        "libp2p": "~0.25.4",
+        "libp2p": "~0.26.1",
         "libp2p-bootstrap": "~0.9.3",
         "libp2p-crypto": "~0.16.0",
         "libp2p-delegated-content-routing": "^0.2.4",
         "libp2p-delegated-peer-routing": "^0.2.4",
+        "libp2p-floodsub": "^0.18.0",
+        "libp2p-gossipsub": "~0.0.5",
         "libp2p-kad-dht": "~0.15.3",
         "libp2p-keychain": "~0.4.2",
         "libp2p-mdns": "~0.12.0",
         "libp2p-record": "~0.6.3",
         "libp2p-secio": "~0.11.0",
-        "libp2p-tcp": "~0.13.0",
+        "libp2p-tcp": "~0.13.1",
         "libp2p-webrtc-star": "~0.16.0",
         "libp2p-websocket-star-multi": "~0.4.3",
-        "libp2p-websockets": "~0.12.2",
+        "libp2p-websockets": "~0.12.3",
         "lodash": "^4.17.15",
-        "mafmt": "^6.0.2",
+        "mafmt": "^6.0.10",
         "merge-options": "^1.0.1",
         "mime-types": "^2.1.21",
         "mkdirp": "~0.5.1",
+        "mortice": "^2.0.0",
         "multiaddr": "^6.1.0",
-        "multiaddr-to-uri": "^4.0.1",
+        "multiaddr-to-uri": "^5.0.0",
         "multibase": "~0.6.0",
         "multicodec": "~0.5.5",
         "multihashes": "~0.4.14",
@@ -10506,6 +10877,7 @@
         "progress": "^2.0.1",
         "prom-client": "^11.5.3",
         "prometheus-gc-stats": "~0.6.0",
+        "promise-nodeify": "^3.0.1",
         "promisify-es6": "^1.0.3",
         "protons": "^1.0.1",
         "pull-abortable": "^4.1.1",
@@ -10516,7 +10888,7 @@
         "pull-ndjson": "~0.1.1",
         "pull-pushable": "^2.2.0",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.13",
+        "pull-stream": "^3.6.14",
         "pull-stream-to-async-iterator": "^1.0.2",
         "pull-stream-to-stream": "^1.3.4",
         "pull-traverse": "^1.0.3",
@@ -10524,23 +10896,51 @@
         "receptacle": "^1.3.2",
         "semver": "^6.3.0",
         "stream-to-pull-stream": "^1.7.3",
-        "superstruct": "~0.6.0",
+        "superstruct": "~0.6.2",
         "tar-stream": "^2.0.0",
         "temp": "~0.9.0",
         "update-notifier": "^3.0.1",
         "uri-to-multiaddr": "^3.0.1",
         "varint": "^5.0.0",
-        "yargs": "^13.3.0",
+        "yargs": "^14.0.0",
         "yargs-promise": "^1.1.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "concat-stream": {
+          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+          "from": "github:hugomrdias/concat-stream#feat/smaller",
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2"
           }
         },
         "debug": {
@@ -10551,29 +10951,145 @@
             "ms": "^2.1.1"
           }
         },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
         "err-code": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
           "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
         },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "ipfs-http-client": {
+          "version": "37.0.3",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-37.0.3.tgz",
+          "integrity": "sha512-yv8lVWGUWcAX5K1K5gj0uWjIBmvbS0hIhnStC4Da+RTJL09jFj9LsBYySst8F3pmU6XfqOurwihlFmK79ZChyg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "async": "^2.6.1",
+            "async-iterator-all": "^1.0.0",
+            "async-iterator-to-pull-stream": "^1.3.0",
+            "bignumber.js": "^9.0.0",
+            "bl": "^3.0.0",
+            "bs58": "^4.0.1",
+            "buffer": "^5.4.2",
+            "cids": "~0.7.1",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+            "debug": "^4.1.0",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "end-of-stream": "^1.4.1",
+            "err-code": "^2.0.0",
+            "explain-error": "^1.0.4",
+            "flatmap": "0.0.3",
+            "form-data": "^2.5.1",
+            "fs-extra": "^8.1.0",
+            "glob": "^7.1.3",
+            "ipfs-block": "~0.8.1",
+            "ipfs-utils": "^0.4.0",
+            "ipld-dag-cbor": "~0.15.0",
+            "ipld-dag-pb": "~0.17.3",
+            "ipld-raw": "^4.0.0",
+            "is-ipfs": "~0.6.1",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "iso-stream-http": "~0.1.2",
+            "iso-url": "~0.4.6",
+            "it-glob": "0.0.4",
+            "it-to-stream": "^0.1.1",
+            "iterable-ndjson": "^1.1.0",
+            "just-kebab-case": "^1.1.0",
+            "just-map-keys": "^1.1.0",
+            "kind-of": "^6.0.2",
+            "ky": "^0.14.0",
+            "ky-universal": "^0.3.0",
+            "lru-cache": "^5.1.1",
+            "merge-options": "^1.0.1",
+            "multiaddr": "^6.0.6",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+            "once": "^1.4.0",
+            "peer-id": "~0.12.3",
+            "peer-info": "~0.15.1",
+            "promise-nodeify": "^3.0.1",
+            "promisify-es6": "^1.0.3",
+            "pull-defer": "~0.2.3",
+            "pull-stream": "^3.6.9",
+            "pull-stream-to-async-iterator": "^1.0.2",
+            "pull-to-stream": "~0.1.1",
+            "pump": "^3.0.0",
+            "qs": "^6.5.2",
+            "readable-stream": "^3.1.1",
+            "stream-to-pull-stream": "^1.7.2",
+            "tar-stream": "^2.0.1",
+            "through2": "^3.0.1"
+          },
+          "dependencies": {
+            "ipfs-utils": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.4.0.tgz",
+              "integrity": "sha512-JLFmCcA058knmYiSB+WBw6nxcDHFS6p05weQOTFR/edufYot0UpgsJTcoMd1fHMq81n0nciJ3QQBqLcJxqGqhA==",
+              "requires": {
+                "buffer": "^5.2.1",
+                "err-code": "^2.0.0",
+                "fs-extra": "^8.1.0",
+                "is-buffer": "^2.0.3",
+                "is-electron": "^2.2.0",
+                "is-pull-stream": "0.0.0",
+                "is-stream": "^2.0.0",
+                "it-glob": "0.0.4",
+                "kind-of": "^6.0.2",
+                "pull-stream-to-async-iterator": "^1.0.2",
+                "readable-stream": "^3.4.0"
+              }
+            }
+          }
+        },
         "ipfs-utils": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
-          "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.3.0.tgz",
+          "integrity": "sha512-5xrOYv27lA8gV13K6Zm8gIUvNtqwmHCqztxnVE4S6aTdfMNkXQJJhRvlsi7RN/auHMORPxc3qSRMukgEUO3C2Q==",
           "requires": {
             "buffer": "^5.2.1",
+            "err-code": "^2.0.0",
+            "fs-extra": "^8.1.0",
             "is-buffer": "^2.0.3",
             "is-electron": "^2.2.0",
             "is-pull-stream": "0.0.0",
             "is-stream": "^2.0.0",
+            "it-glob": "0.0.4",
             "kind-of": "^6.0.2",
+            "pull-stream-to-async-iterator": "^1.0.2",
             "readable-stream": "^3.4.0"
           }
         },
         "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-stream": {
           "version": "2.0.0",
@@ -10584,6 +11100,22 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "mafmt": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+          "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
+          "requires": {
+            "multiaddr": "^6.1.0"
+          }
         },
         "ms": {
           "version": "2.1.2",
@@ -10598,6 +11130,20 @@
             "varint": "^5.0.0"
           }
         },
+        "pull-stream": {
+          "version": "3.6.14",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+          "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
         "readable-stream": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
@@ -10608,10 +11154,33 @@
             "util-deprecate": "^1.0.1"
           }
         },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         },
         "tar-stream": {
           "version": "2.1.0",
@@ -10623,6 +11192,56 @@
             "fs-constants": "^1.0.0",
             "inherits": "^2.0.3",
             "readable-stream": "^3.1.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        },
+        "yargs": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+          "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -10882,9 +11501,9 @@
       }
     },
     "ipfs-mfs": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.12.0.tgz",
-      "integrity": "sha512-EY+At/kw2Lsyfd/AFInmvR2O6MQvQ87RWhAnN3GXSy/tXaopaS5CqT9SSUVAx3we87/pAUbusxQ1pK7HYtrXSw==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.12.2.tgz",
+      "integrity": "sha512-o9vGKEdUI4HwQV67DQnC1AVSSs7i/yaIHrKPEb6Oe6vGeobLGuEGMReWjTcnMi5KAKUECFESEVtDuNJDr8BW5Q==",
       "requires": {
         "@hapi/boom": "^7.4.2",
         "@hapi/joi": "^15.1.0",
@@ -10894,13 +11513,13 @@
         "err-code": "^1.1.2",
         "hamt-sharding": "~0.0.2",
         "interface-datastore": "~0.6.0",
-        "ipfs-multipart": "~0.1.0",
+        "ipfs-multipart": "~0.2.0",
         "ipfs-unixfs": "~0.1.16",
         "ipfs-unixfs-exporter": "~0.37.6",
         "ipfs-unixfs-importer": "~0.39.9",
         "ipld-dag-pb": "~0.17.2",
         "joi-browser": "^13.4.0",
-        "mortice": "^1.2.1",
+        "mortice": "^2.0.0",
         "multicodec": "~0.5.3",
         "multihashes": "~0.4.14",
         "once": "^1.4.0",
@@ -10924,12 +11543,12 @@
       }
     },
     "ipfs-multipart": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.1.1.tgz",
-      "integrity": "sha512-NAmCxgBkZ0usWXf8lMwYYEXvyzrqa65uy/1caVKm5yOKFoqXNrNOt4Ev99Pb+B0RMRqGSdfSvtnZM1cfhSSk2A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.2.0.tgz",
+      "integrity": "sha512-pDCr7xtOW7KCqgeGmejfWjm5xPH516Kx4OU/PdbtIZu68/cFPW4jftJy9idQHdf0C/NnKHnqntMY93rbc+qrQg==",
       "requires": {
         "@hapi/content": "^4.1.0",
-        "dicer": "~0.3.0"
+        "it-multipart": "~0.0.2"
       }
     },
     "ipfs-repo": {
@@ -11027,9 +11646,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11306,9 +11925,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11419,9 +12038,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11456,9 +12075,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11526,9 +12145,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -12219,10 +12838,95 @@
         "is-object": "^1.0.1"
       }
     },
+    "it-glob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.4.tgz",
+      "integrity": "sha512-sTMM62VQWRqlMpgbd+x1uTviQY7a8vMLXYmw+KPiV9vmAYuyIr9Sp1QRQ5B/faybf4O9RzMGyQb7eFpqLwsBhQ==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-multipart": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-0.0.2.tgz",
+      "integrity": "sha512-Mlvf1Tt+gLyk5EkE9njjfDCuvf5+3rx1vDt271MT7Ye08/3yJL/h+M/EWhPBPLebmNrkfXUQOGl8ud4T9PzuWA==",
+      "requires": {
+        "buffer-indexof": "^1.1.1",
+        "parse-headers": "^2.0.2"
+      }
+    },
+    "it-pipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.0.1.tgz",
+      "integrity": "sha512-clx7NMIf4eXe3rp4dKLmT5vMYv/hvZv4lNi1/xx4ZJ8CFmpGod9rTKisyBNBTurbCEa3a7503COankdBj/uUCA=="
+    },
+    "it-to-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.1.tgz",
+      "integrity": "sha512-QQx/58JBvT189imr6fD234F8aVf8EdyQHJR0MxXAOShEWK1NWyahPYIQt/tQG7PId0ZG/6/3tUiVCfw2cq+e1w==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "p-defer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "items": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
       "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     },
     "jmespath": {
       "version": "0.15.0",
@@ -12402,10 +13106,10 @@
       "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-1.1.0.tgz",
       "integrity": "sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg=="
     },
-    "just-flatten-it": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/just-flatten-it/-/just-flatten-it-2.1.0.tgz",
-      "integrity": "sha512-mX3NUt/LF6EzohLJZXhywCwz2zqdhx6wVkEu6UfUx00lVQlSB6SBV1O+/Le15NfsimrWRD82H69ZkSVQZffhmw=="
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
     },
     "just-kebab-case": {
       "version": "1.1.0",
@@ -12701,6 +13405,20 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
+    "ky": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.14.0.tgz",
+      "integrity": "sha512-NSjg+WCElQPdlF3BFZnjh8s5QlMIP+vIGoyukrRU+n+23VBUX87bQYOoG5h3HX5tO7kKQYXvg+QZVt8n0uWmhg=="
+    },
+    "ky-universal": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
+      "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.0"
+      }
     },
     "latency-monitor": {
       "version": "0.2.1",
@@ -13004,26 +13722,40 @@
       }
     },
     "libp2p": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.25.5.tgz",
-      "integrity": "sha512-vkUGFkPcY7t/LyyIbjKbF7KE4O+gPmJXvv363TjmNSZX/ph0aP8KtCpurxwo82ztxec3w5XCZUyNGrjEliSshw==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.26.2.tgz",
+      "integrity": "sha512-AaPSpROjrg17QBMood6tdxLj3yWH5qR/pnQ4gurz3byvYvD6Tw3yt7PQRdSyjOh6Oh+EX06yTrNCnoDTdgliKg==",
       "requires": {
         "async": "^2.6.2",
+        "bignumber.js": "^9.0.0",
+        "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^1.1.2",
         "fsm-event": "^2.1.0",
-        "libp2p-connection-manager": "^0.1.0",
-        "libp2p-floodsub": "^0.16.1",
-        "libp2p-ping": "^0.8.5",
-        "libp2p-switch": "^0.42.12",
+        "hashlru": "^2.3.0",
+        "interface-connection": "~0.3.3",
+        "latency-monitor": "~0.2.1",
+        "libp2p-crypto": "~0.16.1",
         "libp2p-websockets": "^0.12.2",
         "mafmt": "^6.0.7",
+        "merge-options": "^1.0.1",
+        "moving-average": "^1.0.0",
         "multiaddr": "^6.1.0",
+        "multistream-select": "~0.14.6",
         "once": "^1.4.0",
         "peer-book": "^0.9.1",
         "peer-id": "^0.12.2",
-        "peer-info": "^0.15.1",
-        "superstruct": "^0.6.0"
+        "peer-info": "~0.15.1",
+        "promisify-es6": "^1.0.3",
+        "protons": "^1.0.1",
+        "pull-cat": "^1.1.11",
+        "pull-defer": "~0.2.3",
+        "pull-handshake": "^1.1.4",
+        "pull-reader": "^1.3.1",
+        "pull-stream": "^3.6.9",
+        "retimer": "^2.0.0",
+        "superstruct": "^0.6.0",
+        "xsalsa20": "^1.0.2"
       },
       "dependencies": {
         "debug": {
@@ -13052,65 +13784,6 @@
         "multiaddr": "^6.0.3",
         "peer-id": "~0.12.2",
         "peer-info": "~0.15.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "libp2p-circuit": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.3.7.tgz",
-      "integrity": "sha512-Z14T3D1YYE1W2k9QtheyxzfwGpEi4Tk4gDofSmAhKqlfCQcctNvKdv0udgjnwzZjXRBtAmNzVJfxZ2WagtZotA==",
-      "requires": {
-        "async": "^2.6.2",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.0.6",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "protons": "^1.0.1",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.2",
-        "pull-pair": "^1.1.0",
-        "pull-stream": "^3.6.9"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "libp2p-connection-manager": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libp2p-connection-manager/-/libp2p-connection-manager-0.1.0.tgz",
-      "integrity": "sha512-Md5UERlkD+KUsdUQRJE+B+UBq/KwOTo650z8Bl0zEfKjfnv/yMeFhucnf14suYBnzIIdGsckYn66xbeki31BLw==",
-      "requires": {
-        "debug": "^4.1.1",
-        "latency-monitor": "~0.2.1"
       },
       "dependencies": {
         "debug": {
@@ -13204,30 +13877,6 @@
         "p-queue": "^6.1.0",
         "peer-id": "^0.12.2",
         "peer-info": "^0.15.1"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
-        },
-        "p-queue": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.0.tgz",
-          "integrity": "sha512-907vNz/cY+JEsqGglo7o/Ia9E/wisahJGOp9HPfbAyCVGERQVmFGA4IyknxY1v+QRBiMKedL3ToOBXNEy9MKQA==",
-          "requires": {
-            "eventemitter3": "^4.0.0",
-            "p-timeout": "^3.1.0"
-          }
-        },
-        "p-timeout": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz",
-          "integrity": "sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==",
-          "requires": {
-            "p-finally": "^1.0.0"
-          }
-        }
       }
     },
     "libp2p-delegated-peer-routing": {
@@ -13239,43 +13888,19 @@
         "p-queue": "^6.1.0",
         "peer-id": "^0.12.2",
         "peer-info": "^0.15.1"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
-        },
-        "p-queue": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.0.tgz",
-          "integrity": "sha512-907vNz/cY+JEsqGglo7o/Ia9E/wisahJGOp9HPfbAyCVGERQVmFGA4IyknxY1v+QRBiMKedL3ToOBXNEy9MKQA==",
-          "requires": {
-            "eventemitter3": "^4.0.0",
-            "p-timeout": "^3.1.0"
-          }
-        },
-        "p-timeout": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz",
-          "integrity": "sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==",
-          "requires": {
-            "p-finally": "^1.0.0"
-          }
-        }
       }
     },
     "libp2p-floodsub": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.16.1.tgz",
-      "integrity": "sha512-3Y+BMwlgit5LGKFUwEn5hNH9+WvhK4mkSEKe7mu0xtQ0KmFvwUpYt+UO/By1iZRpYDyEhQ8rya0ZJtYcqFkxvg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.18.0.tgz",
+      "integrity": "sha512-4OihLP5A4LsxNPlfb0mq6vkjAaNu4YxuyYeoj2nNgrRSzr4H8Dz0YtA+DzEDXIgP2RBANSzS+KG9oDeUXDHa/Q==",
       "requires": {
         "async": "^2.6.2",
         "bs58": "^4.0.1",
         "debug": "^4.1.1",
         "length-prefixed-stream": "^2.0.0",
         "libp2p-crypto": "~0.16.1",
-        "libp2p-pubsub": "~0.1.0",
+        "libp2p-pubsub": "~0.2.0",
         "protons": "^1.0.1",
         "pull-length-prefixed": "^1.3.2",
         "pull-pushable": "^2.2.0",
@@ -13297,17 +13922,53 @@
         }
       }
     },
-    "libp2p-identify": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.6.tgz",
-      "integrity": "sha512-QleYqI6f8ah6G6sQU9uaIa9FVOtyp6LtiqopfjrmAIO5Oz22Zw+dpT7FcEXvYP7kL036Es2vzZm0js0pOWw1MA==",
+    "libp2p-gossipsub": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.0.5.tgz",
+      "integrity": "sha512-7IM9hcSkc7pBWEju/a5ZGcUrEHclgVoUU7XPrMsMB7s5QNXziSbLjJvIBlgU7WOxoTmgmZldEtHPkrsPEb1C9A==",
       "requires": {
-        "multiaddr": "^6.0.4",
+        "async": "^2.6.2",
+        "err-code": "^1.1.2",
+        "libp2p-floodsub": "~0.17.1",
+        "libp2p-pubsub": "~0.2.0",
+        "multistream-select": "~0.14.6",
         "peer-id": "~0.12.2",
         "peer-info": "~0.15.1",
         "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.9"
+        "pull-length-prefixed": "^1.3.3",
+        "pull-stream": "^3.6.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "libp2p-floodsub": {
+          "version": "0.17.2",
+          "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.17.2.tgz",
+          "integrity": "sha512-xOljtBcNTerBwRYFnXlJVmTwdYla9YTvBux6HaBE0GvVjPHqOI7gO5WJQ1Nul/7h5qLX5tJqZ4OY5CVn+mcuUQ==",
+          "requires": {
+            "async": "^2.6.2",
+            "bs58": "^4.0.1",
+            "debug": "^4.1.1",
+            "length-prefixed-stream": "^2.0.0",
+            "libp2p-crypto": "~0.16.1",
+            "libp2p-pubsub": "~0.2.0",
+            "protons": "^1.0.1",
+            "pull-length-prefixed": "^1.3.2",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "libp2p-kad-dht": {
@@ -13371,6 +14032,14 @@
             "murmurhash3js": "^3.0.1",
             "nodeify": "^1.0.1"
           }
+        },
+        "p-queue": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-5.0.0.tgz",
+          "integrity": "sha512-6QfeouDf236N+MAxHch0CVIy8o/KBnmhttKjxZoOkUlzqU+u9rZgEyXH3OdckhTgawbqf5rpzmyR+07+Lv0+zg==",
+          "requires": {
+            "eventemitter3": "^3.1.0"
+          }
         }
       }
     },
@@ -13418,20 +14087,10 @@
         }
       }
     },
-    "libp2p-ping": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.5.tgz",
-      "integrity": "sha512-BzCN3+jp1SvJQZlXq2G3TMkyK5UOOf3JO+CZMnaUEHYlRgQf2zShYta5XU2IGx0EJA/23iCdCL+LjBP/DOvbkQ==",
-      "requires": {
-        "libp2p-crypto": "~0.16.0",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.9"
-      }
-    },
     "libp2p-pubsub": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.1.0.tgz",
-      "integrity": "sha512-oppDCIZLmqODAgt1r625yO0j9wy7auro7B6/5bw2WN5ctqTsG791dn3SGVRLV8Dvd7uSfMlOaZ/Bkw8jle0Ytg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.2.1.tgz",
+      "integrity": "sha512-6LFl7b/39LLWKK9v/Oz9F7+c0WX8t2W2Qf2nwyMMCtJDGxC3csvXdhWwUDzBwXx704BJhVgpsVVJ4fXQn5gahg==",
       "requires": {
         "async": "^2.6.2",
         "bs58": "^4.0.1",
@@ -13443,6 +14102,7 @@
         "pull-length-prefixed": "^1.3.1",
         "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.9",
+        "sinon": "^7.3.2",
         "time-cache": "~0.3.0"
       },
       "dependencies": {
@@ -13520,36 +14180,23 @@
         }
       }
     },
-    "libp2p-switch": {
-      "version": "0.42.12",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.42.12.tgz",
-      "integrity": "sha512-aNjJQpP9kSClXXKIliSqIowIoxAy0JQ8hnw6BoqOHUIG9Eov4GVyuOdU6lQKl1ym4uKMsnF2G49qpZJ47O01XA==",
+    "libp2p-tcp": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.2.tgz",
+      "integrity": "sha512-TvHLCn25m+UIH+hXTuy8xJDU/Kxj8EEEgWzhWUImsrb/YsYFywjbuv8YCAYtTUMIzyT2DnTtM+xzPxccg/sytw==",
       "requires": {
-        "async": "^2.6.2",
-        "bignumber.js": "^8.1.1",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "fsm-event": "^2.1.0",
-        "hashlru": "^2.3.0",
         "interface-connection": "~0.3.3",
-        "libp2p-circuit": "~0.3.6",
-        "libp2p-identify": "~0.7.6",
-        "moving-average": "^1.0.0",
-        "multiaddr": "^6.0.6",
-        "multistream-select": "~0.14.4",
+        "ip-address": "^6.1.0",
+        "lodash.includes": "^4.3.0",
+        "lodash.isfunction": "^3.0.9",
+        "mafmt": "^6.0.7",
+        "multiaddr": "^6.1.0",
         "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "pull-stream": "^3.6.9",
-        "retimer": "^2.0.0"
+        "stream-to-pull-stream": "^1.7.3"
       },
       "dependencies": {
-        "bignumber.js": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -13558,57 +14205,35 @@
             "ms": "^2.1.1"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "libp2p-tcp": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.0.tgz",
-      "integrity": "sha512-bsmfxi+uVegK61x9UxBEgWtvujPl+zwzuVEyaVRs2IxHu6OE5MGKnj7AflzlK4e3w2HZn8nm4qwMV5m+fhqK1g==",
-      "requires": {
-        "class-is": "^1.1.0",
-        "debug": "^3.1.0",
-        "interface-connection": "~0.3.2",
-        "ip-address": "^5.8.9",
-        "lodash.includes": "^4.3.0",
-        "lodash.isfunction": "^3.0.9",
-        "mafmt": "^6.0.2",
-        "multiaddr": "^5.0.0",
-        "once": "^1.4.0",
-        "stream-to-pull-stream": "^1.7.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "ip-address": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.1.0.tgz",
+          "integrity": "sha512-u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==",
           "requires": {
-            "ms": "^2.1.1"
+            "jsbn": "1.1.0",
+            "lodash": "^4.17.15",
+            "sprintf-js": "1.1.2"
           }
+        },
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
-        "multiaddr": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
-          "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
         }
       }
     },
@@ -13947,15 +14572,15 @@
       }
     },
     "libp2p-websockets": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.2.tgz",
-      "integrity": "sha512-K/Jg/fWFfP5NyiLx01EJcoAcYQO00RSHpZfPQDR3May6ABvOseAjq45SrUDdDCW5mCS0502Vz1VjRrZdOXw8zQ==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.4.tgz",
+      "integrity": "sha512-wXrdFgBibvuD+b+s1KIvhlbzh/qCXSDBmzkoKUugftxV6tC5AhotbHW1JlcI726+U+z4k8ha3nEZd9PY64NLqQ==",
       "requires": {
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
-        "interface-connection": "~0.3.2",
-        "mafmt": "^6.0.4",
-        "multiaddr-to-uri": "^4.0.1",
+        "interface-connection": "~0.3.3",
+        "mafmt": "^6.0.7",
+        "multiaddr-to-uri": "^5.0.0",
         "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
       },
       "dependencies": {
@@ -14303,6 +14928,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
     },
     "long": {
       "version": "4.0.0",
@@ -15075,12 +15705,13 @@
       }
     },
     "mortice": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mortice/-/mortice-1.2.2.tgz",
-      "integrity": "sha512-zECpP0bCFVxlAbIJST7ZHQPm5ECKsJRaw4JfSmu5XQeSkO+UB8i+1GUxkskqLHHQfj/wGRWNDd8KBkWfHaZZkw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-2.0.0.tgz",
+      "integrity": "sha512-rXcjRgv2MRhpwGHErxKcDcp5IoA9CPvPFLXmmseQYIuQ2fSVu8tsMKi/eYUXzp/HH1s6y3IID/GwRqlSglDdRA==",
       "requires": {
+        "globalthis": "^1.0.0",
         "observable-webworkers": "^1.0.0",
-        "p-queue": "^5.0.0",
+        "p-queue": "^6.0.0",
         "promise-timeout": "^1.3.0",
         "shortid": "^2.2.8"
       }
@@ -15127,11 +15758,11 @@
       }
     },
     "multiaddr-to-uri": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-4.0.1.tgz",
-      "integrity": "sha512-RVHKm5NXcMWMIhrwF4B4Q34JtMXt1/2wgnDTnKRE+AGAiXfqFika0bIfCsAtLp+gZJOWeDLeT1vR6P0gGyVAtg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.0.0.tgz",
+      "integrity": "sha512-aVc52fdGXso3DwvVKUTjMddhLyuFBXcpGSbsIju0lKiYKFBUEREXSLpcqTOZlO8w1G1TivVmDe4CBUKQ/xMm5A==",
       "requires": {
-        "multiaddr": "^6.0.3"
+        "multiaddr": "^6.1.0"
       }
     },
     "multibase": {
@@ -15374,6 +16005,33 @@
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
           "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        }
+      }
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
         }
       }
     },
@@ -16120,6 +16778,22 @@
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+        }
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -16152,11 +16826,27 @@
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-queue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-5.0.0.tgz",
-      "integrity": "sha512-6QfeouDf236N+MAxHch0CVIy8o/KBnmhttKjxZoOkUlzqU+u9rZgEyXH3OdckhTgawbqf5rpzmyR+07+Lv0+zg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.1.tgz",
+      "integrity": "sha512-R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==",
       "requires": {
-        "eventemitter3": "^3.1.0"
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        },
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        }
       }
     },
     "p-timeout": {
@@ -16359,6 +17049,15 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
+    },
+    "parse-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
+      "requires": {
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
+      }
     },
     "parse-json": {
       "version": "4.0.0",
@@ -16670,12 +17369,12 @@
       }
     },
     "pino": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.1.tgz",
-      "integrity": "sha512-IxusG28L0g50uuf21kZELypdFOeNrJ/kRhktdi7LtdZQWCxLliMxG5iOrGUQ/ng7MiJ4XqXi/hfyXwZeKc1MxA==",
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.4.tgz",
+      "integrity": "sha512-heeg8m8FZY8Nl3nuuD+msJUmhamqoGl7JXoTExh9YpGajzz6LYbVByUqrjbf4sCEMYFsqdcqnTJWiSY660DraQ==",
       "requires": {
-        "fast-redact": "^1.4.4",
-        "fast-safe-stringify": "^2.0.6",
+        "fast-redact": "^2.0.0",
+        "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.9",
         "pino-std-serializers": "^2.3.0",
         "quick-format-unescaped": "^3.0.2",
@@ -16683,19 +17382,19 @@
       }
     },
     "pino-pretty": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-2.6.1.tgz",
-      "integrity": "sha512-e/CWtKLidqkr7sinfIVVcsfcHgnFVlGvuEfKuuPFnxBo+9dZZsmgF8a9Rj7SYJ5LMZ8YBxNY9Ca46eam4ajKtQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-3.2.1.tgz",
+      "integrity": "sha512-PGdcRYw7HCF7ovMhrnepOUmEVh5+tATydRrBICEbP37oRasXV+lo2HA9gg8b7cE7LG6G1OZGVXTZ7MLd946k1Q==",
       "requires": {
-        "args": "^5.0.0",
-        "chalk": "^2.3.2",
+        "@hapi/bourne": "^1.3.2",
+        "args": "^5.0.1",
+        "chalk": "^2.4.2",
         "dateformat": "^3.0.3",
-        "fast-json-parse": "^1.0.3",
         "fast-safe-stringify": "^2.0.6",
         "jmespath": "^0.15.0",
         "pump": "^3.0.0",
-        "readable-stream": "^3.0.6",
-        "split2": "^3.0.0"
+        "readable-stream": "^3.3.0",
+        "split2": "^3.1.1"
       },
       "dependencies": {
         "pump": {
@@ -17017,6 +17716,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
+    "promise-nodeify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
+      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg=="
+    },
     "promise-timeout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
@@ -17266,9 +17970,9 @@
       }
     },
     "pull-split": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.0.tgz",
-      "integrity": "sha1-mW0ohTEFIgmoMTiK0NKB3zyCN5Y=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.1.tgz",
+      "integrity": "sha512-lloBKx+ijuRNvxvhM/SMJQ0r9/0WBGcpCPv8I6MZuYl4D1heUF/eYQObnqVehhtTMYuMwboK7RdhMa4Wg3YB7w==",
       "requires": {
         "pull-through": "~1.0.6"
       }
@@ -17427,10 +18131,15 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
+    "queue-microtask": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.2.tgz",
+      "integrity": "sha512-F9wwNePtXrzZenAB3ax0Y8TSKGvuB7Qw16J30hspEUTbfUM+H827XyN3rlpwhVmtm5wuZtbKIHjOnwDn7MUxWQ=="
+    },
     "quick-format-unescaped": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
-      "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -18440,9 +19149,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-filename": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.2.tgz",
-      "integrity": "sha512-cmTzND7RMxUB+f7gI+4+KAVHWEg0lfXvQJdko+FXDP5bNbGIdx4KMP5pX6lv5jfT9jSf6OBbjyxjFtZQwYA/ig==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }
@@ -18717,13 +19426,13 @@
       }
     },
     "simple-peer": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.5.0.tgz",
-      "integrity": "sha512-3tROq3nBo/CIZI8PWlXGbAxQIlQF6KQ/zcd4lQ2pAC4+rPiV7E721hI22nTO54uw/nzb2HKbvmDtZ4Wr173+vA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.6.0.tgz",
+      "integrity": "sha512-NYqSKPu75xhkZYKGJhCbLCG5kfBtDHf8U9ddk4EKFfYNU7XgIisov+V8wMbVVgyMCfn8pm8uOqQQmE50FPDFWA==",
       "requires": {
         "debug": "^4.0.1",
         "get-browser-rtc": "^1.0.0",
-        "inherits": "^2.0.1",
+        "queue-microtask": "^1.1.0",
         "randombytes": "^2.0.3",
         "readable-stream": "^3.4.0"
       },
@@ -18759,6 +19468,27 @@
       "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
       "requires": {
         "string-width": "^1.0.1"
+      }
+    },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        }
       }
     },
     "slash": {
@@ -19021,9 +19751,9 @@
       }
     },
     "sonic-boom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.5.tgz",
-      "integrity": "sha512-1pKrnAV6RfvntPnarY71tpthFTM3pWZWWQdghZY8ARjtDPGzG/inxqSuRwQY/7V1woUjfyxPb437zn4p5phgnQ==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
+      "integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
       "requires": {
         "flatstr": "^1.0.12"
       }
@@ -19456,11 +20186,6 @@
         }
       }
     },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
     "strftime": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
@@ -19484,6 +20209,16 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -19647,9 +20382,9 @@
       }
     },
     "superstruct": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.1.tgz",
-      "integrity": "sha512-LDbOKL5sNbOJ00Q36iYRhSexKIptZje0/mhNznnz04wT9CmsPDZg/K/UV1dgYuCwNMuOBHTbVROZsGB9EhhK4w==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.2.tgz",
+      "integrity": "sha512-lvA97MFAJng3rfjcafT/zGTSWm6Tbpk++DP6It4Qg7oNaeM+2tdJMuVgGje21/bIpBEs6iQql1PJH6dKTjl4Ig==",
       "requires": {
         "clone-deep": "^2.0.1",
         "kind-of": "^6.0.1"
@@ -20688,9 +21423,9 @@
       }
     },
     "varuint-bitcoin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
       "requires": {
         "safe-buffer": "^5.1.1"
       }
@@ -21409,6 +22144,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
       "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
+    },
+    "xsalsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.0.2.tgz",
+      "integrity": "sha512-g1DFmZ5JJ9Qzvt4dMw6m9IydqoCSP381ucU5zm46Owbk3bwmqAr8eEJirOPc7PrXRn45drzOpAyDp8jsnoyXyw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "form-data": "^2.3.3",
     "go-ipfs-dep": "~0.4.20",
     "hat": "~0.0.3",
-    "ipfs": "^0.37.0",
+    "ipfs": "^0.38.0",
     "ipfs-http-client": "^33.1.0",
     "ipfs-repo": "~0.26.6",
     "ipfs-unixfs": "~0.1.16",

--- a/test/circuit/browser.js
+++ b/test/circuit/browser.js
@@ -86,8 +86,8 @@ module.exports = {
   'go-browser-browser': {
     create: (callback) => series([
       (cb) => createGo([`${base}/ws`], cb),
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb),
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb)
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb),
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb)
     ], callback),
     connect: (nodeA, nodeB, relay, callback) => {
       series([
@@ -103,8 +103,8 @@ module.exports = {
   'js-browser-browser': {
     create: (callback) => series([
       (cb) => createJs([`${base}/ws`], cb),
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb),
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb)
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb),
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb)
     ], callback),
     connect: (nodeA, nodeB, relay, callback) => {
       series([
@@ -118,8 +118,8 @@ module.exports = {
   },
   'browser-browser-go': {
     create: (callback) => series([
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb),
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb),
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb),
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb),
       (cb) => createGo([`${base}/ws`], cb)
     ], callback),
     connect: (nodeA, nodeB, relay, callback) => {
@@ -134,8 +134,8 @@ module.exports = {
   },
   'browser-browser-js': {
     create: (callback) => series([
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb),
-      (cb) => createProc([`/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star`], cb),
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb),
+      (cb) => createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-websocket-star'], cb),
       (cb) => createJs([`${base}/ws`], cb)
     ], callback),
     connect: (nodeA, nodeB, relay, callback) => {

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -37,7 +37,7 @@ const waitForTopicPeer = (topic, peer, daemon, callback) => {
 
 const timeout = 20e3
 function createJs () {
-  return spawnInitAndStartJsDaemon({ args: ['--enable-pubsub-experiment'] })
+  return spawnInitAndStartJsDaemon()
 }
 function createGo () {
   return spawnInitAndStartGoDaemon({ args: ['--enable-pubsub-experiment'] })


### PR DESCRIPTION
js-IPFS v0.38.0 shipped with pubsub enabled by default so it's no longer necessary to pass the enable-pubsub flag to the daemon.