### PR TITLE
chore: avoid double travis build for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: node_js
 cache: npm
+
+# only build PRs and master
+branches:
+  only:
+  - master
+
 stages:
   - check
   - test


### PR DESCRIPTION
Disable building branches that aren't master - builds will happen for all PRs anyway, so this change means we don't get a branch build *and* a PR build on each PR.