### PR TITLE
feat: pass extra cli args to npm test command

### DIFF
--- a/bin/ipfs-interop.js
+++ b/bin/ipfs-interop.js
@@ -4,7 +4,7 @@
 
 const { spawn } = require('child_process')
 
-const proc = spawn('npm', ['test'], {
+const proc = spawn('npm', ['test'].concat(process.argv.slice(2)), {
   cwd: __dirname
 })
 proc.stdout.pipe(process.stdout)


### PR DESCRIPTION
Lets us keep env config in `package.json` instead of `.travis.yml` and do things like:

```console
$ npm run test:interop:browser
```

which will then invoke a npm script like:

```json
{
  "scripts": {
    "test:interop:browser": "IPFS_JS_MODULE=`pwd` npm run test:interop -- -t browser"
  }
}
```
