### PR TITLE
chore: install ipfs, go-ipfs-dep and ipfs-http-client as dev deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ os:
   - osx
 
 script:
-  - npm install ipfs go-ipfs-dep ipfs-http-client
   - npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
@@ -39,7 +38,6 @@ jobs:
       addons:
         chrome: stable
       script:
-       - npm install ipfs go-ipfs-dep ipfs-http-client
        - npx aegir test -t browser
 
     - stage: test
@@ -47,7 +45,6 @@ jobs:
       addons:
         firefox: latest
       script:
-        - npm install ipfs go-ipfs-dep ipfs-http-client
         - npx aegir test -t browser -- --browsers FirefoxHeadless
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -67,11 +67,14 @@
   },
   "contributors": [],
   "devDependencies": {
+    "go-ipfs-dep": "~0.4.22",
+    "ipfs": "^0.39.0",
+    "ipfs-http-client": "^39.0.2",
     "karma-mocha-webworker": "^1.3.0"
   },
   "peerDependencies": {
-    "go-ipfs-dep": "~0.4.22",
-    "ipfs": "^0.39.0",
-    "ipfs-http-client": "^39.0.2"
+    "go-ipfs-dep": "*",
+    "ipfs": "*",
+    "ipfs-http-client": "*"
   }
 }


### PR DESCRIPTION
This will let us run our tests without needing extra installs in .travis.yml.