### PR TITLE
fix: disable test with small file and raw leaves

### DIFF
--- a/test/files.js
+++ b/test/files.js
@@ -300,7 +300,9 @@ describe('files', function () {
       )
     })
 
-    it('small files with CIDv1', () => {
+    // skipped because small files with raw leaves should still result in a UnixFS entry
+    // https://github.com/ipfs/go-ipfs/issues/6940
+    it.skip('small files with CIDv1', () => {
       const data = Buffer.from([0x00, 0x01, 0x02])
       const options = {
         cidVersion: 1


### PR DESCRIPTION
Disabled temporarily until https://github.com/ipfs/go-ipfs/issues/6940 is implemented in go-IPFS.