### PR TITLE
fix: override ipfs module location

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -10,7 +10,7 @@ let ipfsdServer
 module.exports = {
   webpack: {
     plugins: [
-      new webpack.EnvironmentPlugin(['IPFS_JS_EXEC', 'IPFS_JS_MODULE'])
+      new webpack.EnvironmentPlugin(['IPFS_JS_EXEC'])
     ]
   },
   karma: {
@@ -21,7 +21,20 @@ module.exports = {
       included: false
     }],
     singleRun: true,
-    browserNoActivityTimeout: 100 * 1000
+    browserNoActivityTimeout: 100 * 1000,
+    webpack: {
+      resolve: {
+        alias: {
+          ipfs$: process.env.IPFS_JS_MODULE
+        }
+      },
+      plugins: [
+        new webpack.DefinePlugin({
+          // override js module location because we override `require('ipfs')` above
+          'process.env.IPFS_JS_MODULE': 'undefined'
+        })
+      ]
+    }
   },
   hooks: {
     browser: {

--- a/.aegir.js
+++ b/.aegir.js
@@ -25,13 +25,15 @@ module.exports = {
     webpack: {
       resolve: {
         alias: {
-          ipfs$: process.env.IPFS_JS_MODULE
+          ipfs$: process.env.IPFS_JS_MODULE,
+          'ipfs-http-client$': process.env.IPFS_JS_HTTP_MODULE,
         }
       },
       plugins: [
         new webpack.DefinePlugin({
-          // override js module location because we override `require('ipfs')` above
-          'process.env.IPFS_JS_MODULE': 'undefined'
+          // override js module locations because we override them above
+          'process.env.IPFS_JS_MODULE': 'undefined',
+          'process.env.IPFS_JS_HTTP_MODULE': 'undefined'
         })
       ]
     }

--- a/.aegir.js
+++ b/.aegir.js
@@ -25,8 +25,8 @@ module.exports = {
     webpack: {
       resolve: {
         alias: {
-          ipfs$: process.env.IPFS_JS_MODULE,
-          'ipfs-http-client$': process.env.IPFS_JS_HTTP_MODULE,
+          ipfs$: process.env.IPFS_JS_MODULE || require.resolve('ipfs'),
+          'ipfs-http-client$': process.env.IPFS_JS_HTTP_MODULE || require.resolve('ipfs-http-client'),
         }
       },
       plugins: [

--- a/test/utils/daemon-factory.js
+++ b/test/utils/daemon-factory.js
@@ -2,22 +2,29 @@
 
 const { createFactory } = require('ipfsd-ctl')
 const isNode = require('detect-node')
-let IPFS
+let ipfsModule
+let ipfsHttpModule
 
 // webpack requires conditional includes to be done this way
 if (process.env.IPFS_JS_MODULE) {
-  IPFS = require(process.env.IPFS_JS_MODULE)
+  ipfsModule = require(process.env.IPFS_JS_MODULE)
 } else {
-  IPFS = require('ipfs')
+  ipfsModule = require('ipfs')
+}
+
+if (process.env.IPFS_JS_HTTP_MODULE) {
+  ipfsHttpModule = require(process.env.IPFS_JS_HTTP_MODULE)
+} else {
+  ipfsHttpModule = require('ipfs-http-client')
 }
 
 module.exports = createFactory({
   type: 'go',
   test: true,
-  ipfsHttpModule: require('ipfs-http-client')
+  ipfsHttpModule
 }, {
   proc: {
-    ipfsModule: IPFS
+    ipfsModule
   },
   js: {
     ipfsBin: isNode ? process.env.IPFS_JS_EXEC || require.resolve(`${process.env.IPFS_JS_MODULE || 'ipfs'}/src/cli/bin.js`) : undefined


### PR DESCRIPTION
Uses webpack config to override where `require('ipfs')` is resolved to instead of using the `IPFS_JS_MODULE` env var which seems to have stopped working since we stopped including all of the users' env in production builds in aegir.