### PR TITLE
fix: go-ipfs 0.5 sync

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -47,7 +47,7 @@ module.exports = {
         }, {
           type: 'go',
           test: true,
-          ipfsHttpModule: require('ipfs-http-client')
+          ipfsHttpModule: require(process.env.IPFS_JS_HTTP_MODULE || 'ipfs-http-client')
         }, {
           go: {
             ipfsBin: process.env.IPFS_GO_EXEC || require('go-ipfs-dep').path()

--- a/test/files.js
+++ b/test/files.js
@@ -354,7 +354,7 @@ describe('files', function () {
 
     it('rabin chunker small chunks', () => {
       const options = {
-        chunker: 'rabin-16-16-16',
+        chunker: 'rabin-16-32-64',
         pin: false,
         preload: false
       }

--- a/test/pin.js
+++ b/test/pin.js
@@ -134,7 +134,7 @@ describe('pin', function () {
       expect(goPins).to.deep.include.members(jsPins)
       expect(jsPins).to.deep.include.members(goPins)
 
-      const dirPin = goPins.find(pin => pin.hash === jupiterDir.hash)
+      const dirPin = goPins.find(pin => pin.cid.equals(jupiterDir.cid))
       expect(dirPin.type).to.eql('indirect')
     })
   })


### PR DESCRIPTION
- fix remote node ipfs http client path
- fix rabin params go-ipfs has validation and returns errors
- fix use cid instead of hash in the pin tests