### PR TITLE
chore: update deps to test against go-ipfs 0.5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2174,9 +2174,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
-      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -3885,9 +3885,9 @@
       "dev": true
     },
     "bitcoinjs-lib": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.7.tgz",
-      "integrity": "sha512-sNlTQuvhaoIjOdIdyENsX74Dlikv7l6AzO0/uZQscuvfBID6aMANoCz1rooCTH5upTV5rKCj4z3BXBmXJxq23g==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.8.tgz",
+      "integrity": "sha512-LQQ9uw33sqW3K1aSzYCy0Az8zbcsR1ttaNkjThFwApT/vbB7bibEesPIxf0zvzjf8V8It68v7D/fCkjd4bStMw==",
       "dev": true,
       "requires": {
         "bech32": "^1.1.2",
@@ -4292,23 +4292,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
-    "buffer-split": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-split/-/buffer-split-1.0.0.tgz",
-      "integrity": "sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=",
-      "dev": true,
-      "requires": {
-        "buffer-indexof": "~0.0.0"
-      },
-      "dependencies": {
-        "buffer-indexof": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz",
-          "integrity": "sha1-7Q82t64WamanzRdMBGeuje3wCPU=",
-          "dev": true
-        }
-      }
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -4727,40 +4710,36 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cid-tool": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.4.0.tgz",
-      "integrity": "sha512-nsH5JcmhdPTLuShxwJgIgo3qdVdk7w1pnNMcjalynvG8bfVSrcZfjKLALINMUgnoOOLIkFqkuYo8/K4YIo6SJw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.4.1.tgz",
+      "integrity": "sha512-nASd+T8H9hY1Z3Z9ylvWlUUCFZ1msFaGAx7Y9+peqJEbrnSLErJXT8YJFRyUtkkP8+0NYE9g8JRUhC5+pj8SJw==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.0",
+        "cids": "~0.8.0",
         "explain-error": "^1.0.4",
-        "multibase": "~0.6.0",
+        "multibase": "~0.7.0",
         "multihashes": "~0.4.14",
         "split2": "^3.1.1",
         "yargs": "^15.0.2"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "dev": true,
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "safe-buffer": "^5.0.1"
           }
         },
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
           }
         },
         "readable-stream": {
@@ -6190,76 +6169,13 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "dag-cbor-links": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.2.tgz",
-      "integrity": "sha512-QbGzsx6uOXkMo66tuG0EzwhARIZzyK1Kt0EsrFmysO+tpv7jfVLTWakYY7WeH6RD2sTPKHGpWlxaMCROPS6M8A==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.4.tgz",
+      "integrity": "sha512-+4yAa3YQo4hucbdT+zsb/8nj5ZXsb4iIm/LzeUdUBv4zwfhR7Z5DJ1WNZTJvNh4XUO1fLOBRxCrlwnn5BqoNqg==",
       "dev": true,
       "requires": {
-        "cids": "^0.7.1",
-        "dag-cbor-sync": "^0.6.2"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        }
-      }
-    },
-    "dag-cbor-sync": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dag-cbor-sync/-/dag-cbor-sync-0.6.3.tgz",
-      "integrity": "sha512-nrnPol1rE09lLOoTPWmrswyqB0nuycCqlTr6iqjVAL7h0JzF51w4cjF2CSwmg79b13eNh+E2q2+/gz6qRrkFig==",
-      "dev": true,
-      "requires": {
-        "borc": "^2.0.3",
-        "cids": "^0.7.1",
-        "ipfs-block": "^0.8.0",
-        "is-circular": "^1.0.1",
-        "multihashing-async": "^0.8.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        }
+        "cids": "^0.8.0",
+        "ipld-dag-cbor": "^0.15.2"
       }
     },
     "dargs": {
@@ -6268,26 +6184,16 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg=="
     },
     "datastore-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.0.0.tgz",
-      "integrity": "sha512-BS3bH+OOdW3ehY03awN6OhLhv6XvYUuQZBSUoIDA8qEyASBGj3nkBVfJBOEqozBXA0Q4/4QumkRxJfYnqrDy5w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.1.0.tgz",
+      "integrity": "sha512-tn42Qy6t1V5otG4R3hq7yW4vpNaKc8/GXEYnLv8oeGNSQfEWPnfz1x5Sto080N7IsluzOUWK/W+a4m4Er8DnAA==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "debug": "^4.1.1",
-        "interface-datastore": "^0.8.2"
+        "interface-datastore": "^1.0.2"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6297,68 +6203,27 @@
             "ms": "^2.1.1"
           }
         },
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
         "interface-datastore": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
-          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
+          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
           "dev": true,
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
             "err-code": "^2.0.0",
-            "ipfs-utils": "^1.2.3",
+            "ipfs-utils": "^2.2.2",
             "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
             "nanoid": "^3.0.2"
           }
         },
-        "ipfs-utils": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
-          "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^5.4.2",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.0",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.7",
-            "merge-options": "^2.0.0",
-            "nanoid": "^2.1.11",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
-          },
-          "dependencies": {
-            "nanoid": {
-              "version": "2.1.11",
-              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-              "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-              "dev": true
-            }
-          }
-        },
-        "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
-          }
+        "it-all": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
+          "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -6367,145 +6232,166 @@
           "dev": true
         },
         "nanoid": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.3.tgz",
-          "integrity": "sha512-Zw8rTOUfh6FlKgkEbHiB1buOF2zOPOQyGirABUWn+9Z7m9PpyoLVkh6Ksc53vBjndINQ2+9LfRPaHxb/u45EGg==",
-          "dev": true
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
           "dev": true
         }
       }
     },
     "datastore-fs": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.9.1.tgz",
-      "integrity": "sha512-clhkqbYzpe/L0mKVBjXB7hxBpzDbYkMOG2aBH5jepSpmKmouJhp01yzUrqB6zRz01hEN0u2r4kosTVKJ3K4sUA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-1.1.0.tgz",
+      "integrity": "sha512-z/lsSMxi7omrPwCgGjZ1OrPN0cq35sFMWhTHnnF1ekvD3fxntB1gNqEi9ioMMJNX8OQap7JvYT40LdtZZx7mTg==",
       "dev": true,
       "requires": {
-        "datastore-core": "~0.7.0",
-        "fast-write-atomic": "~0.2.0",
+        "datastore-core": "^1.1.0",
+        "fast-write-atomic": "^0.2.0",
         "glob": "^7.1.3",
-        "interface-datastore": "~0.7.0",
-        "mkdirp": "~0.5.1"
+        "interface-datastore": "^1.0.2",
+        "mkdirp": "^1.0.4"
       },
       "dependencies": {
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
+        "interface-datastore": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
+          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
           "dev": true,
           "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^2.2.2",
+            "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "nanoid": "^3.0.2"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+        "it-all": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
+          "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg==",
           "dev": true
         },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "nanoid": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
+          "dev": true
+        }
+      }
+    },
+    "datastore-idb": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-idb/-/datastore-idb-1.1.0.tgz",
+      "integrity": "sha512-tsUp0rs6QoQ/AUOjcnNZ2cJYLfS0f5izkkH3yxYIIlFG/FQwZs9JBGRQBK8wxNjM4T5D6lIlMpQLx+FwAB0eww==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "idb": "^5.0.2",
+        "interface-datastore": "^1.0.2"
+      },
+      "dependencies": {
         "interface-datastore": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-          "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
+          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
           "dev": true,
           "requires": {
+            "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^1.1.2",
-            "uuid": "^3.2.2"
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^2.2.2",
+            "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "nanoid": "^3.0.2"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+        "it-all": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
+          "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg==",
+          "dev": true
+        },
+        "nanoid": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
           "dev": true
         }
       }
     },
     "datastore-level": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.14.1.tgz",
-      "integrity": "sha512-gAXD11GfxMfUWkhFr3GebZjGxnHabnz6pOgxFw/6MddAE3pOfHCbPPssYdGGSDv+nl0jwhNrsncGdlQ/FvPpcg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-1.1.0.tgz",
+      "integrity": "sha512-XEuXC3mq2BTUdhOvx7vwD93GN1O8SJf1HL/EOlmVcxLt3EHtDpX5pqZmiDdrXIAfe4uiEuSfFu2tKycuz1PMZA==",
       "dev": true,
       "requires": {
-        "datastore-core": "~0.7.0",
-        "interface-datastore": "^0.8.0",
+        "datastore-core": "^1.1.0",
+        "interface-datastore": "^1.0.2",
         "level": "^5.0.1"
       },
       "dependencies": {
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
+        "interface-datastore": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
+          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
           "dev": true,
           "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
-          },
-          "dependencies": {
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^2.2.2",
+            "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "nanoid": "^3.0.2"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+        "it-all": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
+          "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg==",
           "dev": true
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+        "nanoid": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
           "dev": true
         }
       }
     },
     "datastore-pubsub": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.3.0.tgz",
-      "integrity": "sha512-OlpwhvdHpZU0+JHgSLTGfafHifayS0zJa6Q+dH4dqQI+FEuUSjffBlL8uia8S8OY+r1fxVOpDmd/yCbx1J+EEg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.3.2.tgz",
+      "integrity": "sha512-NEBtuwLToPdzHEBQ+Gb+IBAFV+1Rm6CyFK323987+cNG001tFe5Qnly8MhlG/qOKX4/CdoKGw0bP/DIv4m0/ig==",
       "dev": true,
       "requires": {
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "interface-datastore": "~0.8.0",
-        "multibase": "~0.6.0"
+        "interface-datastore": "^1.0.2",
+        "multibase": "^0.7.0"
       },
       "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6515,10 +6401,48 @@
             "ms": "^2.1.1"
           }
         },
+        "interface-datastore": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
+          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^2.2.2",
+            "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "nanoid": "^3.0.2"
+          }
+        },
+        "it-all": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
+          "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "nanoid": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
           "dev": true
         }
       }
@@ -6659,16 +6583,6 @@
             "level-concat-iterator": "~2.0.0",
             "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
-          }
-        },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
           }
         }
       }
@@ -6910,9 +6824,9 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-match-patch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
-      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "dev": true
     },
     "diffie-hellman": {
@@ -7623,16 +7537,6 @@
             "level-concat-iterator": "~2.0.0",
             "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
-          }
-        },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
           }
         }
       }
@@ -8426,9 +8330,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
-      "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.1.tgz",
+      "integrity": "sha512-aVUPRLgmXORGXXEVkFYgPhr9TGtpBY2tGhZ9Uh0A3lIUzUDr1x6kQx33SbjPUkLkX3eniPQnIL/2psjkjrOfcQ==",
       "dev": true
     },
     "ethereumjs-tx": {
@@ -8952,9 +8856,9 @@
       }
     },
     "file-type": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.1.4.tgz",
-      "integrity": "sha512-1n6FczX8n73Y/cLjTiMboeTGHfm/i2AWk2oQE7m9a/G5YTCZHCEHEGr32thhLm3iQNUYzTKVQUcYcNHtOLwqgQ==",
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.5.0.tgz",
+      "integrity": "sha512-hIxIT/8DPClkKbC+IEoZvcQ5aBhsivh4aWzLMvmkp9Uabzey7gFNNPmTOwp8O/b2DkJ8a4FkFMkyFzkyRVsJXg==",
       "dev": true,
       "requires": {
         "readable-web-to-node-stream": "^2.0.0",
@@ -10684,9 +10588,9 @@
       }
     },
     "go-ipfs-dep": {
-      "version": "0.4.23-3",
-      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.23-3.tgz",
-      "integrity": "sha512-jdLKEax5pGVoPJn2ZayYSGt0SXPI9osr6cj87cWB9PGJ7p/tkPSzMHNpVHwYU1aY9SjUcuU8KzqMUn1KOCK5FA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.5.1.tgz",
+      "integrity": "sha512-N8SB3VJLIIGwWATAJkAbvnwv8e4ddb0krrG4FhMq71uP0gu90itAG3ZujYZV0gkJH1rWK+U7huaPpFk6QU4rbQ==",
       "dev": true,
       "requires": {
         "go-platform": "^1.0.0",
@@ -10732,9 +10636,9 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
     "gunzip-maybe": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
-      "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
+      "integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
       "dev": true,
       "requires": {
         "browserify-zlib": "^0.1.4",
@@ -11242,6 +11146,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.3.tgz",
+      "integrity": "sha512-ozfTR2owoslXWtfyQU2/tEUK1SXkCUb7gLq0wpvGWM8EZRwHr1rajEQGVsWT1bgfBiAenj/OXTn7h+PskWAwbA==",
+      "dev": true
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -11501,9 +11411,9 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.43.0.tgz",
-      "integrity": "sha512-LJd+dcTu2ZPSZEpBcpCbjArhHsP6qRU58m0qyfLKmgCWUGTD6LzqzKlQ0P+l2YMpJLzYsuUMkjnZUZAvSAKvcQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.44.0.tgz",
+      "integrity": "sha512-KfCHpvKJgtDcuJOmNpLNMz1qtiwrkheu6XSqiVFwPsKqWb9ijREQSKxEVQrLsOrkxMgKyREvsY00J+F8RLremw==",
       "dev": true,
       "requires": {
         "@hapi/ammo": "^3.1.2",
@@ -11516,16 +11426,17 @@
         "array-shuffle": "^1.0.1",
         "bignumber.js": "^9.0.0",
         "binary-querystring": "^0.1.2",
-        "bl": "^4.0.0",
+        "bl": "^4.0.2",
         "bs58": "^4.0.1",
+        "buffer": "^5.6.0",
         "byteman": "^1.3.5",
         "cid-tool": "^0.4.0",
         "cids": "^0.8.0",
         "class-is": "^1.1.0",
-        "dag-cbor-links": "^1.3.2",
+        "dag-cbor-links": "^1.3.3",
         "datastore-core": "^1.0.0",
-        "datastore-level": "^0.14.1",
-        "datastore-pubsub": "^0.3.0",
+        "datastore-level": "^1.0.0",
+        "datastore-pubsub": "^0.3.1",
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
@@ -11535,29 +11446,30 @@
         "hamt-sharding": "^1.0.0",
         "hapi-pino": "^6.1.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^0.8.0",
-        "ipfs-bitswap": "^0.27.1",
-        "ipfs-block": "^0.8.1",
+        "interface-datastore": "^0.8.3",
+        "ipfs-bitswap": "^0.27.2",
         "ipfs-block-service": "^0.16.0",
-        "ipfs-core-utils": "^0.2.0",
-        "ipfs-http-client": "^44.0.0",
+        "ipfs-core-utils": "^0.2.3",
+        "ipfs-http-client": "^44.1.0",
         "ipfs-http-response": "^0.5.0",
-        "ipfs-repo": "^1.0.1",
-        "ipfs-unixfs": "^1.0.1",
-        "ipfs-unixfs-exporter": "^1.0.3",
-        "ipfs-unixfs-importer": "^1.0.3",
-        "ipfs-utils": "^2.2.0",
-        "ipld": "^0.25.0",
+        "ipfs-repo": "^2.0.1",
+        "ipfs-unixfs": "^1.0.2",
+        "ipfs-unixfs-exporter": "^2.0.1",
+        "ipfs-unixfs-importer": "^2.0.1",
+        "ipfs-utils": "^2.2.2",
+        "ipld": "^0.26.2",
         "ipld-bitcoin": "^0.3.0",
-        "ipld-dag-cbor": "^0.15.1",
-        "ipld-dag-pb": "^0.18.3",
+        "ipld-block": "^0.9.1",
+        "ipld-dag-cbor": "^0.15.2",
+        "ipld-dag-pb": "^0.18.5",
         "ipld-ethereum": "^4.0.0",
         "ipld-git": "^0.5.0",
         "ipld-raw": "^4.0.1",
         "ipld-zcash": "^0.4.0",
-        "ipns": "^0.7.0",
+        "ipns": "^0.7.1",
         "is-domain-name": "^1.0.1",
-        "is-ipfs": "^1.0.0",
+        "is-ipfs": "^1.0.3",
+        "iso-url": "^0.4.7",
         "it-all": "^1.0.1",
         "it-concat": "^1.0.0",
         "it-drain": "^1.0.0",
@@ -11566,47 +11478,47 @@
         "it-map": "^1.0.0",
         "it-multipart": "^1.0.1",
         "it-pipe": "^1.1.0",
-        "it-tar": "^1.2.1",
+        "it-tar": "^1.2.2",
         "it-to-stream": "^0.1.1",
         "iterable-ndjson": "^1.1.0",
         "jsondiffpatch": "^0.4.1",
         "just-safe-set": "^2.1.0",
-        "libp2p": "^0.27.2",
+        "libp2p": "^0.27.7",
         "libp2p-bootstrap": "^0.10.3",
-        "libp2p-crypto": "^0.17.1",
+        "libp2p-crypto": "^0.17.6",
         "libp2p-delegated-content-routing": "^0.4.4",
         "libp2p-delegated-peer-routing": "^0.4.2",
         "libp2p-floodsub": "^0.20.0",
-        "libp2p-gossipsub": "^0.2.3",
-        "libp2p-kad-dht": "^0.18.3",
+        "libp2p-gossipsub": "^0.3.0",
+        "libp2p-kad-dht": "^0.18.7",
         "libp2p-keychain": "^0.6.0",
         "libp2p-mdns": "^0.13.1",
         "libp2p-mplex": "^0.9.3",
-        "libp2p-record": "^0.7.0",
+        "libp2p-record": "^0.7.3",
         "libp2p-secio": "^0.12.2",
-        "libp2p-tcp": "^0.14.3",
-        "libp2p-webrtc-star": "^0.17.6",
+        "libp2p-tcp": "^0.14.5",
+        "libp2p-webrtc-star": "^0.17.10",
         "libp2p-websockets": "^0.13.3",
         "mafmt": "^7.0.0",
         "merge-options": "^2.0.0",
         "mortice": "^2.0.0",
-        "multiaddr": "^7.2.1",
+        "multiaddr": "^7.4.3",
         "multiaddr-to-uri": "^5.1.0",
         "multibase": "^0.7.0",
         "multicodec": "^1.0.0",
-        "multihashes": "^0.4.14",
+        "multihashes": "^0.4.19",
         "multihashing-async": "^0.8.0",
         "p-defer": "^3.0.0",
         "p-queue": "^6.1.0",
         "parse-duration": "^0.1.2",
-        "peer-id": "^0.13.5",
+        "peer-id": "^0.13.12",
         "peer-info": "^0.17.0",
         "pretty-bytes": "^5.3.0",
         "progress": "^2.0.1",
         "prom-client": "^12.0.0",
         "prometheus-gc-stats": "^0.6.0",
-        "protons": "^1.0.1",
-        "semver": "^7.1.2",
+        "protons": "^1.2.0",
+        "semver": "^7.3.2",
         "stream-to-it": "^0.2.0",
         "streaming-iterables": "^4.1.1",
         "temp": "^0.9.0",
@@ -11645,6 +11557,12 @@
             "safe-buffer": "^5.0.1"
           }
         },
+        "base64id": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+          "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+          "dev": true
+        },
         "bl": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
@@ -11656,15 +11574,11 @@
             "readable-stream": "^3.4.0"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
         },
         "debug": {
           "version": "4.1.1",
@@ -11673,6 +11587,69 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "engine.io": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.1.tgz",
+          "integrity": "sha512-8MfIfF1/IIfxuc2gv5K+XlFZczw/BpTvqBdl0E2fBLkYQp4miv4LuDTVtYt4yMyaIFLEr4vtaSgV4mjvll8Crw==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "base64id": "2.0.0",
+            "cookie": "0.3.1",
+            "debug": "~4.1.0",
+            "engine.io-parser": "~2.2.0",
+            "ws": "^7.1.2"
+          }
+        },
+        "engine.io-client": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.2.tgz",
+          "integrity": "sha512-AWjc1Xg06a6UPFOBAzJf48W1UR/qKYmv/ubgSCumo9GXgvL/xGIvo05dXoBL+2NTLMipDI7in8xK61C17L25xg==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "~1.3.0",
+            "component-inherit": "0.0.3",
+            "debug": "~4.1.0",
+            "engine.io-parser": "~2.2.0",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "~6.1.0",
+            "xmlhttprequest-ssl": "~1.5.4",
+            "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+              "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+              "dev": true
+            },
+            "ws": {
+              "version": "6.1.4",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+              "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+              "dev": true,
+              "requires": {
+                "async-limiter": "~1.0.0"
+              }
+            }
+          }
+        },
+        "engine.io-parser": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+          "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+          "dev": true,
+          "requires": {
+            "after": "0.8.2",
+            "arraybuffer.slice": "~0.0.7",
+            "base64-arraybuffer": "0.1.5",
+            "blob": "0.0.5",
+            "has-binary2": "~1.0.2"
           }
         },
         "fs-extra": {
@@ -11687,34 +11664,193 @@
             "universalify": "^1.0.0"
           }
         },
-        "ipfs-unixfs": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.1.tgz",
-          "integrity": "sha512-P1G9eVywOFtItONEiAvOgPIUO7hZjBC1FK3iiTXRDOrtM8S1K0fxgF9lGG+mZUeE5WPjyiuQEiMrSmqym27Efw==",
+        "interface-datastore": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
+          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
           "dev": true,
           "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
             "err-code": "^2.0.0",
-            "protons": "^1.1.0"
+            "ipfs-utils": "^1.2.3",
+            "iso-random-stream": "^1.1.1",
+            "nanoid": "^3.0.2"
+          },
+          "dependencies": {
+            "ipfs-utils": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+              "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+              "dev": true,
+              "requires": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^5.4.2",
+                "err-code": "^2.0.0",
+                "fs-extra": "^9.0.0",
+                "is-electron": "^2.2.0",
+                "iso-url": "^0.4.7",
+                "it-glob": "0.0.7",
+                "merge-options": "^2.0.0",
+                "nanoid": "^2.1.11",
+                "node-fetch": "^2.6.0",
+                "stream-to-it": "^0.2.0"
+              },
+              "dependencies": {
+                "nanoid": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+                  "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
+                  "dev": true
+                }
+              }
+            }
           }
         },
-        "ipfs-utils": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.2.0.tgz",
-          "integrity": "sha512-V4pq/BYpWupB+QdVEBnNl/B7uMx3glLVCGAQRGI66DQJTa78vdcEyD8XeRB4wUUFMbxUo1s0J0CH/pJsYNgF9A==",
+        "ipfs-core-utils": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.2.3.tgz",
+          "integrity": "sha512-byg9BgtDVBA1MPGngW6moCc5sF1BHFeR/QUUsfGkarNUoXvbLEYLWygFFlV9dAb7+ge9xgGgp1cdQ9LatU0pmg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^2.2.2"
+          }
+        },
+        "ipfs-http-client": {
+          "version": "44.1.0",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-44.1.0.tgz",
+          "integrity": "sha512-1zgBMPLI7Heomj14xxeY96kwDQDOarRMBIbik/YAnIrFcgIiBxRHtJr2FytQuLjZqwmeqT4rSUqfKLXaWcMLwA==",
           "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
-            "buffer": "^5.4.2",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.0",
-            "is-electron": "^2.2.0",
+            "any-signal": "^1.1.0",
+            "bignumber.js": "^9.0.0",
+            "buffer": "^5.6.0",
+            "cids": "^0.8.0",
+            "debug": "^4.1.0",
+            "form-data": "^3.0.0",
+            "ipfs-core-utils": "^0.2.3",
+            "ipfs-utils": "^2.2.2",
+            "ipld-block": "^0.9.1",
+            "ipld-dag-cbor": "^0.15.2",
+            "ipld-dag-pb": "^0.18.5",
+            "ipld-raw": "^4.0.1",
             "iso-url": "^0.4.7",
-            "it-glob": "0.0.7",
+            "it-tar": "^1.2.2",
+            "it-to-buffer": "^1.0.0",
+            "it-to-stream": "^0.1.1",
             "merge-options": "^2.0.0",
-            "nanoid": "^3.1.3",
+            "multiaddr": "^7.4.3",
+            "multiaddr-to-uri": "^5.1.0",
+            "multibase": "^0.7.0",
+            "multicodec": "^1.0.0",
+            "multihashes": "^0.4.19",
+            "nanoid": "^3.0.2",
             "node-fetch": "^2.6.0",
+            "parse-duration": "^0.1.2",
             "stream-to-it": "^0.2.0"
           }
+        },
+        "ipfs-unixfs": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.2.tgz",
+          "integrity": "sha512-+TucOvxUjSiNSn0eh7aiRaP+KkZC7IM8BnmVammbsUczKbzsWhxQfdgYRQk/btct/KvJeJkF0SVlKLd3MwJ/UQ==",
+          "dev": true,
+          "requires": {
+            "err-code": "^2.0.0",
+            "protons": "^1.2.0"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.18.5",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
+          "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.1",
+            "multihashing-async": "~0.8.1",
+            "protons": "^1.0.2",
+            "stable": "^0.1.8"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
+              "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "varint": "^5.0.0"
+              }
+            },
+            "multihashing-async": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+              "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+              "dev": true,
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "~0.8.0",
+                "multihashes": "~0.4.15",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ipns": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.7.2.tgz",
+          "integrity": "sha512-IY2D9ly8c/7Kg+ZP68qCn0Auv77oy9FRE//tqtlmvPzHhVB0OfVYCuoWwLa0XP5ATSOh4fmETDZyYDHv3vAaQQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "err-code": "^2.0.0",
+            "interface-datastore": "^1.0.2",
+            "libp2p-crypto": "^0.17.1",
+            "multibase": "^0.7.0",
+            "multihashes": "~0.4.14",
+            "peer-id": "^0.13.6",
+            "protons": "^1.0.1",
+            "timestamp-nano": "^1.0.0"
+          },
+          "dependencies": {
+            "interface-datastore": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
+              "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "class-is": "^1.1.0",
+                "err-code": "^2.0.0",
+                "ipfs-utils": "^2.2.2",
+                "iso-random-stream": "^1.1.1",
+                "it-all": "^1.0.2",
+                "it-drain": "^1.0.1",
+                "nanoid": "^3.0.2"
+              }
+            },
+            "it-all": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
+              "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg==",
+              "dev": true
+            }
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         },
         "jsonfile": {
           "version": "6.0.1",
@@ -11726,11 +11862,98 @@
             "universalify": "^1.0.0"
           }
         },
+        "libp2p-crypto": {
+          "version": "0.17.6",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.6.tgz",
+          "integrity": "sha512-ixTSlXXObarf2x+8voGBywr2SyiZh4nw21ZRe1FVz4sxg47crXLqBXhb7gGy2U6Kf0ANbTVaOgLs45WAtM/HpQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^0.7.0",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "~0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.0.1",
+            "secp256k1": "^4.0.0",
+            "ursa-optional": "~0.10.1"
+          },
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+              "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+              "dev": true,
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "~0.8.0",
+                "multihashes": "~0.4.15",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
+          }
+        },
+        "libp2p-webrtc-star": {
+          "version": "0.17.10",
+          "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.17.10.tgz",
+          "integrity": "sha512-9kJhfeu8t33V8dqsNCV5JkUPUMaUV4mw0rhSLeq5aXLAQ0nyxyGua6XdCNxW4Pz1tDMF0H24AAiH/0bnhmvHkQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/hapi": "^18.4.0",
+            "@hapi/inert": "^5.2.2",
+            "abortable-iterator": "^3.0.0",
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "err-code": "^2.0.0",
+            "it-pipe": "^1.0.1",
+            "libp2p-utils": "^0.1.0",
+            "mafmt": "^7.0.1",
+            "menoetius": "0.0.2",
+            "minimist": "^1.2.0",
+            "multiaddr": "^7.1.0",
+            "p-defer": "^3.0.0",
+            "peer-id": "~0.13.2",
+            "peer-info": "~0.17.0",
+            "prom-client": "^12.0.0",
+            "simple-peer": "^9.6.0",
+            "socket.io": "^2.3.0",
+            "socket.io-client": "^2.3.0",
+            "stream-to-it": "^0.2.0",
+            "streaming-iterables": "^4.1.0",
+            "webrtcsupport": "github:ipfs/webrtcsupport"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multiaddr": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.4.3.tgz",
+          "integrity": "sha512-gFjXmjcCMyrx5KF1QOohUQm6a3E2XF4kydvClS8DmRJkY3qJaDPNNe0OC7mWvVUE0nnE8HjyToQfABnpKClXRA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
         },
         "multibase": {
           "version": "0.7.0",
@@ -11742,10 +11965,27 @@
             "buffer": "^5.5.0"
           }
         },
+        "multihashes": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
+          "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
         "nanoid": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.3.tgz",
-          "integrity": "sha512-Zw8rTOUfh6FlKgkEbHiB1buOF2zOPOQyGirABUWn+9Z7m9PpyoLVkh6Ksc53vBjndINQ2+9LfRPaHxb/u45EGg==",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
+          "dev": true
+        },
+        "node-gyp-build": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+          "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
           "dev": true
         },
         "p-defer": {
@@ -11754,14 +11994,31 @@
           "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
           "dev": true
         },
-        "prom-client": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-          "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+        "peer-id": {
+          "version": "0.13.12",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.12.tgz",
+          "integrity": "sha512-kiXu62BdJNeOzqpasMiauTFlDsQmevGWftHrMlUA68FMKWeMAtHFJTDGzaMXwPyH3l1MJM+SYb3APxNLGeZP6A==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "tdigest": "^0.1.1"
+            "buffer": "^5.5.0",
+            "cids": "^0.8.0",
+            "class-is": "^1.1.0",
+            "libp2p-crypto": "~0.17.3",
+            "minimist": "^1.2.5",
+            "multihashes": "~0.4.15",
+            "protons": "^1.0.2"
+          }
+        },
+        "protons": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.0.tgz",
+          "integrity": "sha512-V6wwlbbgZ6qtqd1zRSk7HqvwkoadmeNntUlqd1On9vHyC1tPI6H8GJotfup+9hG2FsDQK+MctaLrSouyunfxNg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
           }
         },
         "readable-stream": {
@@ -11775,64 +12032,136 @@
             "util-deprecate": "^1.0.1"
           }
         },
+        "secp256k1": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
+          "integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
+          "dev": true,
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
+        "socket.io": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
+          "integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
+          "dev": true,
+          "requires": {
+            "debug": "~4.1.0",
+            "engine.io": "~3.4.0",
+            "has-binary2": "~1.0.2",
+            "socket.io-adapter": "~1.1.0",
+            "socket.io-client": "2.3.0",
+            "socket.io-parser": "~3.4.0"
+          }
+        },
+        "socket.io-client": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+          "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "~4.1.0",
+            "engine.io-client": "~3.4.0",
+            "has-binary2": "~1.0.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "~3.3.0",
+            "to-array": "0.1.4"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            },
+            "socket.io-parser": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+              "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+              "dev": true,
+              "requires": {
+                "component-emitter": "1.2.1",
+                "debug": "~3.1.0",
+                "isarray": "2.0.1"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                  "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "socket.io-parser": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
+          "integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "~4.1.0",
+            "isarray": "2.0.1"
+          }
+        },
         "universalify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
           "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
           "dev": true
+        },
+        "ws": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+          "dev": true
         }
       }
     },
     "ipfs-bitswap": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.27.1.tgz",
-      "integrity": "sha512-s0RGRVOq9zyBwzz93y7VSkYL6YbjJPNnkZy4ibPS8N7lRgJgIoO2JLrVgeBLJjlecqVesHMIlgvfIIkjvKRYBA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.27.2.tgz",
+      "integrity": "sha512-OLah2hfvQYYu7/ks/mdHKvVL41BtW+QsJ5nFYJt4RjXVnA5PFYg/OAu5CyyP2ZPQOSIHZo380lzxEUS5DvHgfg==",
       "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0",
-        "cids": "~0.7.0",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.0",
         "debug": "^4.1.0",
-        "ipfs-block": "~0.8.0",
+        "ipld-block": "^0.9.1",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "just-debounce-it": "^1.1.0",
         "moving-average": "^1.0.0",
         "multicodec": "^1.0.0",
         "multihashing-async": "^0.8.0",
-        "protons": "^1.0.1",
+        "protons": "^1.2.0",
         "streaming-iterables": "^4.1.1",
-        "varint-decoder": "~0.1.1"
+        "varint-decoder": "~0.4.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -11847,6 +12176,18 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "protons": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.0.tgz",
+          "integrity": "sha512-V6wwlbbgZ6qtqd1zRSk7HqvwkoadmeNntUlqd1On9vHyC1tPI6H8GJotfup+9hG2FsDQK+MctaLrSouyunfxNg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
         }
       }
     },
@@ -12123,16 +12464,6 @@
         "p-try-each": "^1.0.1"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "cids": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
@@ -12170,58 +12501,40 @@
       }
     },
     "ipfs-repo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-1.0.1.tgz",
-      "integrity": "sha512-4wBESrjx2W+6FoHBsm0k1r+wsq12qPPuMCk0jjh4d3E3R/B7EJYTOsYtieSUo9TlivRmkGY523ykXAl9pbfa1w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-2.1.1.tgz",
+      "integrity": "sha512-xDY9+RMkQIZIOtAlDIy+KRB+6W+QYhJaen05OlMx9qt9LuvTKDjoOo8qJpcBEaS6xj60bIVvtF98SYpj8ngXSw==",
       "dev": true,
       "requires": {
-        "base32.js": "~0.1.0",
         "bignumber.js": "^9.0.0",
+        "buffer": "^5.6.0",
         "bytes": "^3.1.0",
         "cids": "^0.8.0",
-        "datastore-core": "~0.7.0",
-        "datastore-fs": "~0.9.0",
-        "datastore-level": "~0.14.0",
+        "datastore-core": "^1.0.0",
+        "datastore-fs": "^1.0.0",
+        "datastore-idb": "^1.0.2",
+        "datastore-level": "^1.0.0",
         "debug": "^4.1.0",
         "err-code": "^2.0.0",
-        "interface-datastore": "^0.8.0",
-        "ipfs-block": "~0.8.1",
-        "ipfs-repo-migrations": "~0.1.0",
+        "interface-datastore": "^0.8.3",
+        "ipfs-repo-migrations": "^0.2.1",
+        "ipfs-utils": "^2.2.0",
+        "ipld-block": "^0.9.1",
         "just-safe-get": "^2.0.0",
         "just-safe-set": "^2.1.0",
-        "lodash.has": "^4.5.2",
+        "multibase": "^0.7.0",
         "p-queue": "^6.0.0",
         "proper-lockfile": "^4.0.0",
         "sort-keys": "^4.0.0"
       },
       "dependencies": {
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "dev": true,
           "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
-          },
-          "dependencies": {
-            "err-code": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-              "dev": true
-            },
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
+            "safe-buffer": "^5.0.1"
           }
         },
         "debug": {
@@ -12233,16 +12546,97 @@
             "ms": "^2.1.1"
           }
         },
+        "fs-extra": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "interface-datastore": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
+          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^1.2.3",
+            "iso-random-stream": "^1.1.1",
+            "nanoid": "^3.0.2"
+          },
+          "dependencies": {
+            "ipfs-utils": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+              "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+              "dev": true,
+              "requires": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^5.4.2",
+                "err-code": "^2.0.0",
+                "fs-extra": "^9.0.0",
+                "is-electron": "^2.2.0",
+                "iso-url": "^0.4.7",
+                "it-glob": "0.0.7",
+                "merge-options": "^2.0.0",
+                "nanoid": "^2.1.11",
+                "node-fetch": "^2.6.0",
+                "stream-to-it": "^0.2.0"
+              },
+              "dependencies": {
+                "nanoid": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+                  "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
         "is-plain-obj": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "nanoid": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
           "dev": true
         },
         "sort-keys": {
@@ -12253,20 +12647,27 @@
           "requires": {
             "is-plain-obj": "^2.0.0"
           }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
         }
       }
     },
     "ipfs-repo-migrations": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-0.1.1.tgz",
-      "integrity": "sha512-Id8K32l7bEqMt0YxfDUAAiMFkfFr9pslOT0xg3EqTrPc0AeXQ5sZu6y69p5TI7N+A28PhrGgMU40R7IQ8Mb7sg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-0.2.1.tgz",
+      "integrity": "sha512-R046LvO4cewv2H7DcVBHvzGojRu2/WenVAj0uPNgS6zbuLjz7Xz2EcBhpux+ivrQ3oD2ajCjVT3vF3mfQu+0qg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
-        "datastore-fs": "~0.9.1",
-        "datastore-level": "~0.12.1",
+        "buffer": "^5.6.0",
+        "chalk": "^4.0.0",
+        "datastore-fs": "^1.0.0",
+        "datastore-idb": "^1.0.2",
         "debug": "^4.1.0",
-        "interface-datastore": "~0.8.0",
+        "interface-datastore": "~0.8.3",
         "proper-lockfile": "^4.1.1",
         "yargs": "^14.2.0",
         "yargs-promise": "^1.1.0"
@@ -12278,15 +12679,24 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "cliui": {
@@ -12300,52 +12710,20 @@
             "wrap-ansi": "^5.1.0"
           }
         },
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
-          },
-          "dependencies": {
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
+            "color-name": "~1.1.4"
           }
         },
-        "datastore-level": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.12.1.tgz",
-          "integrity": "sha512-PxUIrH/0ijuaJLypOx1XjOIvsZCZcN1qZ3HKyqXFhU8Wpkn01/Q/9nL/MM1tKK1EwOTFmgXKUtFbO27gf6LpcQ==",
-          "dev": true,
-          "requires": {
-            "datastore-core": "~0.7.0",
-            "interface-datastore": "~0.7.0",
-            "level": "^5.0.1"
-          },
-          "dependencies": {
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
-          }
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "debug": {
           "version": "4.1.1",
@@ -12362,11 +12740,17 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-          "dev": true
+        "fs-extra": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
         },
         "get-caller-file": {
           "version": "2.0.5",
@@ -12374,16 +12758,79 @@
           "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "interface-datastore": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
+          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^1.2.3",
+            "iso-random-stream": "^1.1.1",
+            "nanoid": "^3.0.2"
+          }
+        },
+        "ipfs-utils": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+          "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^5.4.2",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.0",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.7",
+            "merge-options": "^2.0.0",
+            "nanoid": "^2.1.11",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          },
+          "dependencies": {
+            "nanoid": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+              "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
+              "dev": true
+            }
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "nanoid": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+          "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
           "dev": true
         },
         "require-main-filename": {
@@ -12412,6 +12859,21 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -12421,6 +12883,32 @@
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
             "strip-ansi": "^5.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            }
           }
         },
         "yargs": {
@@ -12464,48 +12952,61 @@
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-1.1.0.tgz",
-      "integrity": "sha512-hevdVh/XHHwZgYML83DUO9X65XBoAPQHGjaAKE7HRMcxh7okvrMJtIbR08CkfcNKrPCpdiPjyiaOM/Bnnom6eA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-2.0.1.tgz",
+      "integrity": "sha512-DyXM/D7I/dquiXP9HS1MsPwJZYht1KjJkRncgzHstQ6fepKPlC28n1cbPr43/JfYG0GfI5sjhvSI7w3XEou+PQ==",
       "dev": true,
       "requires": {
+        "buffer": "^5.6.0",
         "cids": "^0.8.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^1.0.1",
+        "ipfs-unixfs": "^1.0.2",
         "it-last": "^1.0.1",
         "multihashing-async": "^0.8.0"
       },
       "dependencies": {
         "ipfs-unixfs": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.1.tgz",
-          "integrity": "sha512-P1G9eVywOFtItONEiAvOgPIUO7hZjBC1FK3iiTXRDOrtM8S1K0fxgF9lGG+mZUeE5WPjyiuQEiMrSmqym27Efw==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.2.tgz",
+          "integrity": "sha512-+TucOvxUjSiNSn0eh7aiRaP+KkZC7IM8BnmVammbsUczKbzsWhxQfdgYRQk/btct/KvJeJkF0SVlKLd3MwJ/UQ==",
           "dev": true,
           "requires": {
             "err-code": "^2.0.0",
-            "protons": "^1.1.0"
+            "protons": "^1.2.0"
+          }
+        },
+        "protons": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.0.tgz",
+          "integrity": "sha512-V6wwlbbgZ6qtqd1zRSk7HqvwkoadmeNntUlqd1On9vHyC1tPI6H8GJotfup+9hG2FsDQK+MctaLrSouyunfxNg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
           }
         }
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-1.0.4.tgz",
-      "integrity": "sha512-l1kfIR1WlKkF3prbqG1kHrBwTsj0w5Jm2hTuYxcxdF4UU38Rto8FxmH7/QMIXbJeJgUBrBAcrXasS5T+UJrR9A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-2.0.1.tgz",
+      "integrity": "sha512-N3PRdmreRz4WqaVPmgMSgvL8+mh4Xb7T0c/2kmsdJJem8Dorn0eYe5wJ7pk227uDqq/R6XxAN0dWZt5+hsnwFw==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
+        "buffer": "^5.6.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^1.0.1",
-        "ipld-dag-pb": "^0.18.0",
+        "ipfs-unixfs": "^1.0.2",
+        "ipld-dag-pb": "^0.18.5",
         "it-all": "^1.0.1",
         "it-batch": "^1.0.3",
         "it-first": "^1.0.1",
         "it-parallel-batch": "^1.0.3",
         "merge-options": "^2.0.0",
-        "multicodec": "^1.0.0",
         "multihashing-async": "^0.8.0",
         "rabin-wasm": "^0.1.1"
       },
@@ -12521,24 +13022,67 @@
             "readable-stream": "^3.4.0"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "ipfs-unixfs": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.1.tgz",
-          "integrity": "sha512-P1G9eVywOFtItONEiAvOgPIUO7hZjBC1FK3iiTXRDOrtM8S1K0fxgF9lGG+mZUeE5WPjyiuQEiMrSmqym27Efw==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.2.tgz",
+          "integrity": "sha512-+TucOvxUjSiNSn0eh7aiRaP+KkZC7IM8BnmVammbsUczKbzsWhxQfdgYRQk/btct/KvJeJkF0SVlKLd3MwJ/UQ==",
           "dev": true,
           "requires": {
             "err-code": "^2.0.0",
-            "protons": "^1.1.0"
+            "protons": "^1.2.0"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.18.5",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
+          "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.1",
+            "multihashing-async": "~0.8.1",
+            "protons": "^1.0.2",
+            "stable": "^0.1.8"
+          },
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+              "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+              "dev": true,
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "~0.8.0",
+                "multihashes": "~0.4.15",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
+          }
+        },
+        "multicodec": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
+          "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "protons": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.0.tgz",
+          "integrity": "sha512-V6wwlbbgZ6qtqd1zRSk7HqvwkoadmeNntUlqd1On9vHyC1tPI6H8GJotfup+9hG2FsDQK+MctaLrSouyunfxNg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
           }
         },
         "readable-stream": {
@@ -12870,44 +13414,20 @@
       }
     },
     "ipld": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.25.3.tgz",
-      "integrity": "sha512-DuPTlfAN9Mq/6lN75R7XhEKEg0VHKaHmaKDxKO4atLIMxAAIDwi5pki8TyN81J1tI84uIIUaKuwhwlGGLIyesQ==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.2.tgz",
+      "integrity": "sha512-HGBXh3kBXVGpvmuIaHYn18tBGqNmmaGv4PLgKkKuwqnn6YE/zl/EI5qrKDuPmZ1Vu07GJdacCw2+Tf/PzG3eug==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.1",
-        "ipfs-block": "~0.8.1",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.0",
+        "ipld-block": "~0.9.1",
         "ipld-dag-cbor": "~0.15.0",
         "ipld-dag-pb": "~0.18.1",
         "ipld-raw": "^4.0.0",
         "merge-options": "^2.0.0",
         "multicodec": "^1.0.0",
         "typical": "^6.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        }
       }
     },
     "ipld-bitcoin": {
@@ -12923,16 +13443,6 @@
         "multihashing-async": "~0.8.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "cids": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
@@ -12946,6 +13456,17 @@
             "multihashes": "~0.4.15"
           }
         }
+      }
+    },
+    "ipld-block": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.9.1.tgz",
+      "integrity": "sha512-ypzGNd6VraQx3sU1x8w4/vJPwVKCZgRRLYuXHLJsvW/KQ9xjxN+HkcJgKw2E9up6G7c+1kIWNGnyxsPWjc27pQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "cids": "~0.8.0",
+        "class-is": "^1.1.0"
       }
     },
     "ipld-dag-cbor": {
@@ -13030,16 +13551,6 @@
         "rlp": "^2.2.4"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "cids": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
@@ -13069,16 +13580,6 @@
         "strftime": "~0.10.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "cids": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
@@ -13143,16 +13644,6 @@
         "zcash-block": "^2.0.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "cids": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
@@ -13456,12 +13947,12 @@
       }
     },
     "is-ipfs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-1.0.0.tgz",
-      "integrity": "sha512-5C2sxUZqbXH5oMovtzvM6pog0sBRdScgqMUsqVb5wSj/AdAbY1QRjd7Hpm5IGeKlWpCUTmH5Kpd1JZx0jigB2A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-1.0.3.tgz",
+      "integrity": "sha512-7SAfhxp39rxMvr95qjHMtsle1xa7zXpIbhX/Q77iXKtMVnQ0Fr9AVpAUq+bl3HPXGXDpZJFP0hzWBZaMwD6vGg==",
       "dev": true,
       "requires": {
-        "bs58": "^4.0.1",
+        "buffer": "^5.6.0",
         "cids": "~0.8.0",
         "iso-url": "~0.4.7",
         "mafmt": "^7.1.0",
@@ -13477,16 +13968,6 @@
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
-          }
-        },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
           }
         },
         "multiaddr": {
@@ -13949,9 +14430,9 @@
       "integrity": "sha512-DQ8MQXVfwCktZOja1xvKdsuka7E/OJHpLKLR3tMBmg6Kfo8Kob+XRE6pRfpbkXNsGyET4lMYrQ0y5T3XXF/Akw=="
     },
     "it-batch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.3.tgz",
-      "integrity": "sha512-HCvnTVeA2jH32p1sh1B3f3E1zhXdADJKhoVFSRcVjQA6zpMRUjx2cUWKc7Y8Qa2moJDAHEQxMZS/OVDffek0rw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.4.tgz",
+      "integrity": "sha512-hZ+gaj5MaECauRd+Ahvo9iAxg90YGVBg7AZ32wOeXJ08IRjfQRMSnZ9oA0JjNeJeSGuVjWf91UUD5y2SYmKlwQ==",
       "dev": true
     },
     "it-buffer": {
@@ -13973,16 +14454,6 @@
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
             "readable-stream": "^3.4.0"
-          }
-        },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
           }
         },
         "readable-stream": {
@@ -14027,15 +14498,15 @@
       }
     },
     "it-drain": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.0.tgz",
-      "integrity": "sha512-4oqyA3xvisuRV9kPvMDRMKllupxNrTEj5ajs66l1XP7cf7uro2LQS/lPMh310eHTj/Qz3ieiER0xr/lmtkhpGw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.1.tgz",
+      "integrity": "sha512-4aX8AsJWjRh0inNXGLa90fvxuB7vQY70WFasvskUMtpXXz8+MUH8R7PODBtn4yXCJ25ud2iRwWwa1g8DRDbrlA==",
       "dev": true
     },
     "it-first": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.1.tgz",
-      "integrity": "sha512-+Eka8awisZlNh9/zK0kuad/31PngGpVm9Vo/tb9KkeAKGKUMc2POMxFUvRzj93kODOyBSc0be8k3AbQ6xdPsyg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.2.tgz",
+      "integrity": "sha512-hU5ObR14987PR7l0J7dfWAgKYiWoKbXcoXKqhQDGgHSZML6UPmHSS9ILBGucZkoA2B152kEqEOllS4tVQq11fg==",
       "dev": true
     },
     "it-glob": {
@@ -14099,16 +14570,6 @@
             "readable-stream": "^3.4.0"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -14123,32 +14584,20 @@
       }
     },
     "it-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.1.tgz",
-      "integrity": "sha512-wvyFrogVIxaa2j9i93/z9glkoXOe0Az7+/xFWGF6zEAvMDneIqUzVHDDvysH1/ASZxEtk3K9hw+vthlsVRX8gg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.2.tgz",
+      "integrity": "sha512-WTy7ZK4MDo5B9JgcGz2VLwDxqItUHzv8Mg0YzVM7jhcqY8EdjUuMoAcL7PqzJed+TMy/AYorw47Muc87sdD4sA==",
       "dev": true
     },
     "it-multipart": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-1.0.2.tgz",
-      "integrity": "sha512-nUdSYGzhl3DYJSFEzAcMm/3ycMfZ0h0p2XQ8K8wEfT7fRlGVtWN5YZXeIZemPHe/bIHVwXch6FCZzIhGukmiGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-1.0.3.tgz",
+      "integrity": "sha512-8PSjOl5OSx2fCbBJ73uV4ZVMY0Q/yCQrWHNk6XYXYDwByH5rnSBYEyuSSiOM2grDLY39atybbKTbMi3GWEbACA==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "buffer-indexof": "^1.1.1",
         "parse-headers": "^2.0.2"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        }
       }
     },
     "it-pair": {
@@ -14161,12 +14610,12 @@
       }
     },
     "it-parallel-batch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.3.tgz",
-      "integrity": "sha512-i2AnxP28P+50RYeHTORWRhfj8n/xd/2gCsnkF6+ze8C7f6TklGRIlxGVeZ58z3STvz04WR9eUf2iij/KT6WP2A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.4.tgz",
+      "integrity": "sha512-YyIa0urQO7C/YmWaKAXILv7glvvsfM9jsL+u1CUQxyO8vslLyv9i3LT8AFC55Y9r6xT3A4jK9FhaXND2NmcPFw==",
       "dev": true,
       "requires": {
-        "it-batch": "^1.0.3"
+        "it-batch": "^1.0.4"
       }
     },
     "it-pb-rpc": {
@@ -14385,20 +14834,10 @@
         "ws": "^7.2.1"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "ws": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
           "dev": true
         }
       }
@@ -14413,9 +14852,9 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         },
         "string_decoder": {
@@ -14947,9 +15386,9 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         }
       }
@@ -14976,16 +15415,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-    },
-    "latency-monitor": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/latency-monitor/-/latency-monitor-0.2.1.tgz",
-      "integrity": "sha1-QEPV8j3obiv872ztSjtbki4d1+0=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.0",
-        "lodash": "^4.17.4"
-      }
     },
     "latest-version": {
       "version": "5.1.0",
@@ -15273,16 +15702,6 @@
             "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
           }
-        },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
         }
       }
     },
@@ -15322,9 +15741,9 @@
       }
     },
     "libp2p": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.27.6.tgz",
-      "integrity": "sha512-MDfDWqqdKaC0HyHMiH2H1MBUxqku5HQiSo1vTXbzwaaebSAP7k/9XMBK3pKcaC+CdNxN5Ewjj3t8aurmZyf1Yg==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.27.8.tgz",
+      "integrity": "sha512-0pJrdJ1byAMzDfq+ZZ1WEJXJTofKDsz9f7ezjMjxZxLUlpvb4ncrE3TaRo5TkH1y+D8doFab9q6c9MjST2UVDA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -15334,34 +15753,45 @@
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
+        "events": "^3.1.0",
         "hashlru": "^2.3.0",
+        "ipfs-utils": "^2.2.0",
         "it-all": "^1.0.1",
-        "it-buffer": "^0.1.1",
+        "it-buffer": "^0.1.2",
         "it-handshake": "^1.0.1",
-        "it-length-prefixed": "^3.0.0",
+        "it-length-prefixed": "^3.0.1",
         "it-pipe": "^1.1.0",
         "it-protocol-buffers": "^0.2.0",
-        "latency-monitor": "~0.2.1",
-        "libp2p-crypto": "^0.17.1",
-        "libp2p-interfaces": "^0.2.3",
+        "libp2p-crypto": "^0.17.6",
+        "libp2p-interfaces": "^0.2.8",
         "libp2p-utils": "^0.1.2",
         "mafmt": "^7.0.0",
         "merge-options": "^2.0.0",
         "moving-average": "^1.0.0",
-        "multiaddr": "^7.2.1",
+        "multiaddr": "^7.4.3",
         "multistream-select": "^0.15.0",
         "mutable-proxy": "^1.0.0",
         "p-any": "^3.0.0",
         "p-fifo": "^1.0.0",
-        "p-settle": "^4.0.0",
-        "peer-id": "^0.13.4",
+        "p-settle": "^4.0.1",
+        "peer-id": "^0.13.11",
         "peer-info": "^0.17.0",
         "protons": "^1.0.1",
         "retimer": "^2.0.0",
+        "streaming-iterables": "^4.1.0",
         "timeout-abort-controller": "^1.0.0",
         "xsalsa20": "^1.0.2"
       },
       "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -15369,6 +15799,26 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.17.6",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.6.tgz",
+          "integrity": "sha512-ixTSlXXObarf2x+8voGBywr2SyiZh4nw21ZRe1FVz4sxg47crXLqBXhb7gGy2U6Kf0ANbTVaOgLs45WAtM/HpQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^0.7.0",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "~0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.0.1",
+            "secp256k1": "^4.0.0",
+            "ursa-optional": "~0.10.1"
           }
         },
         "libp2p-utils": {
@@ -15384,11 +15834,87 @@
             "multiaddr": "^7.3.0"
           }
         },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multiaddr": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.4.3.tgz",
+          "integrity": "sha512-gFjXmjcCMyrx5KF1QOohUQm6a3E2XF4kydvClS8DmRJkY3qJaDPNNe0OC7mWvVUE0nnE8HjyToQfABnpKClXRA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+          "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.15",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "node-gyp-build": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+          "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
+          "dev": true
+        },
+        "peer-id": {
+          "version": "0.13.12",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.12.tgz",
+          "integrity": "sha512-kiXu62BdJNeOzqpasMiauTFlDsQmevGWftHrMlUA68FMKWeMAtHFJTDGzaMXwPyH3l1MJM+SYb3APxNLGeZP6A==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "^0.8.0",
+            "class-is": "^1.1.0",
+            "libp2p-crypto": "~0.17.3",
+            "minimist": "^1.2.5",
+            "multihashes": "~0.4.15",
+            "protons": "^1.0.2"
+          }
+        },
+        "secp256k1": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
+          "integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
+          "dev": true,
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
         }
       }
     },
@@ -15516,16 +16042,6 @@
             "safe-buffer": "^5.0.1"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -15607,16 +16123,6 @@
             "safe-buffer": "^5.0.1"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -15645,6 +16151,12 @@
             "secp256k1": "^4.0.0",
             "ursa-optional": "~0.10.1"
           }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -15677,21 +16189,22 @@
           }
         },
         "node-gyp-build": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.1.tgz",
-          "integrity": "sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+          "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
           "dev": true
         },
         "peer-id": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.11.tgz",
-          "integrity": "sha512-CWDPr4ppKslARSe1qfMlGjTiDqL4Hl25Qyfq43PEPAeRD2meI8B2HfxO0NMMB8BUhNvNGPeDAwhLptyB9jVwkw==",
+          "version": "0.13.12",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.12.tgz",
+          "integrity": "sha512-kiXu62BdJNeOzqpasMiauTFlDsQmevGWftHrMlUA68FMKWeMAtHFJTDGzaMXwPyH3l1MJM+SYb3APxNLGeZP6A==",
           "dev": true,
           "requires": {
             "buffer": "^5.5.0",
             "cids": "^0.8.0",
             "class-is": "^1.1.0",
             "libp2p-crypto": "~0.17.3",
+            "minimist": "^1.2.5",
             "multihashes": "~0.4.15",
             "protons": "^1.0.2"
           }
@@ -15709,9 +16222,9 @@
           }
         },
         "secp256k1": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.0.tgz",
-          "integrity": "sha512-0w0zse+Iku13O58SVE9/DhyCKWNsKb+n/vMqLOGICgSqxWuXZs+eajBf9uVOgk5QfNvTY/mx0QSqYxkcz802dw==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
+          "integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
           "dev": true,
           "requires": {
             "elliptic": "^6.5.2",
@@ -15722,12 +16235,13 @@
       }
     },
     "libp2p-floodsub": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.20.2.tgz",
-      "integrity": "sha512-c2vw3xKD6nIGkkrIFjJoMZB6qMiMb8ZteJ3UGYXl5dRBmlyfOQO/zf/vkiNn6yOFwl61OL0QN3yhYyU9gCkFuw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.20.3.tgz",
+      "integrity": "sha512-R/uMu25eLB/tPfkXlV07VOYDV0NRq1gw2WUzl3mh6wqvFPyH7M23U37Gcj39opNobRLPi+fGig8tv8gCVfJjkw==",
       "dev": true,
       "requires": {
         "async.nexttick": "^0.5.2",
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
@@ -15764,17 +16278,18 @@
       }
     },
     "libp2p-gossipsub": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.2.6.tgz",
-      "integrity": "sha512-S+Kpf1GQk3PqFxtXgWECSgCZI8EZW8eo00Pi6N9wVqEnqD83Qsrt2ICEjVf+uIGZ5fxxjwdphxIMBPUIUiMUpg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.3.0.tgz",
+      "integrity": "sha512-tnqf9nr0vc98M8OrpXBMdPWFHxOQqJ9pfdBHgKJ+x4s5VoyLpvjvp8ffHRBGBPestqv2/Pk/64gu+25DCeBU7w==",
       "dev": true,
       "requires": {
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
-        "libp2p-pubsub": "~0.4.1",
-        "p-map": "^3.0.0",
+        "libp2p-pubsub": "~0.4.2",
+        "p-map": "^4.0.0",
         "peer-id": "~0.13.3",
         "peer-info": "~0.17.0",
         "protons": "^1.0.1",
@@ -15795,27 +16310,18 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
         }
       }
     },
     "libp2p-interfaces": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.7.tgz",
-      "integrity": "sha512-CXqc8vYLoJl3riEikXTBjr2xUw8nw2uATax3HazUWMBkvGPf5ONwf+A4LDZSKVuwOWWNMWKbJ1PrD2mGRcRKjw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.8.tgz",
+      "integrity": "sha512-Uzjlzbjk7Bx9giSU2z3qbQv/N8iV9ARL7GV5g9UNCXEYV+lPx0CUX8egnUlxf7/EMjUTz1PsSsf8C7nOZDbVJQ==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "abortable-iterator": "^3.0.0",
-        "buffer": "^5.5.0",
+        "buffer": "^5.6.0",
         "chai": "^4.2.0",
         "chai-checkmark": "^1.0.1",
         "class-is": "^1.1.0",
@@ -15826,36 +16332,141 @@
         "it-pair": "^1.0.0",
         "it-pipe": "^1.0.1",
         "libp2p-tcp": "^0.14.1",
-        "multiaddr": "^7.1.0",
-        "p-limit": "^2.2.2",
+        "multiaddr": "^7.4.3",
+        "p-limit": "^2.3.0",
         "p-wait-for": "^3.1.0",
-        "peer-id": "^0.13.3",
+        "peer-id": "^0.13.11",
         "peer-info": "^0.17.0",
-        "sinon": "^9.0.0",
+        "sinon": "^9.0.2",
         "streaming-iterables": "^4.1.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "dev": true,
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.17.6",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.6.tgz",
+          "integrity": "sha512-ixTSlXXObarf2x+8voGBywr2SyiZh4nw21ZRe1FVz4sxg47crXLqBXhb7gGy2U6Kf0ANbTVaOgLs45WAtM/HpQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^0.7.0",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "~0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.0.1",
+            "secp256k1": "^4.0.0",
+            "ursa-optional": "~0.10.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "multiaddr": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.4.3.tgz",
+          "integrity": "sha512-gFjXmjcCMyrx5KF1QOohUQm6a3E2XF4kydvClS8DmRJkY3qJaDPNNe0OC7mWvVUE0nnE8HjyToQfABnpKClXRA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+          "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.15",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "node-gyp-build": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+          "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "peer-id": {
+          "version": "0.13.12",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.12.tgz",
+          "integrity": "sha512-kiXu62BdJNeOzqpasMiauTFlDsQmevGWftHrMlUA68FMKWeMAtHFJTDGzaMXwPyH3l1MJM+SYb3APxNLGeZP6A==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "^0.8.0",
+            "class-is": "^1.1.0",
+            "libp2p-crypto": "~0.17.3",
+            "minimist": "^1.2.5",
+            "multihashes": "~0.4.15",
+            "protons": "^1.0.2"
+          }
+        },
+        "secp256k1": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
+          "integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
+          "dev": true,
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         }
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.18.6.tgz",
-      "integrity": "sha512-uYoJF6BR0B+8w6/lRqDpVleEqWWv7gd4rign/fkP0zmdD5DYrUYu78NsPVxyXH1UZ5LGwM3xJs9OqMrBt+sqXA==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.18.7.tgz",
+      "integrity": "sha512-qaePQ+hS/1mFsot9HquGETvHhSmiyznyV+UOlHsTdhfUTu5bZEeTefoQDqJZBeZCi1IaEJi1e3Ep+IFJsJFpbg==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "async": "^2.6.2",
         "base32.js": "~0.1.0",
+        "buffer": "^5.6.0",
         "cids": "~0.8.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
@@ -15866,7 +16477,7 @@
         "it-pipe": "^1.1.0",
         "k-bucket": "^5.0.0",
         "libp2p-crypto": "~0.17.1",
-        "libp2p-interfaces": "^0.2.3",
+        "libp2p-interfaces": "^0.2.8",
         "libp2p-record": "~0.7.0",
         "multihashes": "~0.4.15",
         "multihashing-async": "~0.8.0",
@@ -15981,16 +16592,6 @@
             "readable-stream": "^3.4.0"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -16020,12 +16621,11 @@
       }
     },
     "libp2p-pubsub": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.4.3.tgz",
-      "integrity": "sha512-rqNxvD8p7vK+7E/GEcDquWqPDoCbwc4w7s6RLSextR/2oEHY72CFcsSQmajyLYRj1I9jZfBnrV+eB+upMoZ4Pw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.4.4.tgz",
+      "integrity": "sha512-/nFEWjaeKhDLDgXpoqZa1HivvHAQH6RCX9T+VTzQO2aUVoHWOFnrXqBeu5ffjD2DSyyaKtRs1qsLjPVsk3p2zw==",
       "dev": true,
       "requires": {
-        "bs58": "^4.0.1",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "it-length-prefixed": "^3.0.0",
@@ -16033,9 +16633,19 @@
         "it-pushable": "^1.3.2",
         "libp2p-crypto": "~0.17.0",
         "libp2p-interfaces": "^0.2.3",
+        "multibase": "^0.7.0",
         "protons": "^1.0.1"
       },
       "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -16050,16 +16660,26 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
         }
       }
     },
     "libp2p-record": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.7.2.tgz",
-      "integrity": "sha512-s7b3DCweCO6Vq5owk8qjiheUFmLRFfCIrUbFHBY4jdU4ZkP+ZmrAKhx+burPDbqQjhqs1swNJU4Ls77Uf+KY+w==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.7.3.tgz",
+      "integrity": "sha512-a6MrDeVqIkAUaDaiS3vWFu2OblpuBaBmY3bfQY+ZcEI/C2lWB0MixIby9RhrTmR+rqM+W3yoDLQa+clm1HVLhw==",
       "dev": true,
       "requires": {
-        "buffer-split": "^1.0.0",
+        "buffer": "^5.6.0",
         "err-code": "^2.0.0",
         "multihashes": "~0.4.15",
         "multihashing-async": "^0.8.0",
@@ -16067,9 +16687,9 @@
       }
     },
     "libp2p-secio": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.12.4.tgz",
-      "integrity": "sha512-+PrdwN4lS/VypO15s47pCaEI+BtRGcjDEaY6VXcqBKIUG3BPXyhPfeHoLZFh9sTd3BkA4fo4fBRN+0dJ8GV8Lg==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.12.5.tgz",
+      "integrity": "sha512-S4/i7Bye/utt7FBmJS97XNLALAzvKmKLuqnwpUn3lWI1ns+Hx+tWu5lMFIobJu1BNvxapzCHkkq8H5jqqdzlRQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
@@ -16104,16 +16724,6 @@
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
             "readable-stream": "^3.4.0"
-          }
-        },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
           }
         },
         "debug": {
@@ -16178,9 +16788,9 @@
           }
         },
         "node-gyp-build": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.1.tgz",
-          "integrity": "sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+          "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
           "dev": true
         },
         "readable-stream": {
@@ -16195,9 +16805,9 @@
           }
         },
         "secp256k1": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.0.tgz",
-          "integrity": "sha512-0w0zse+Iku13O58SVE9/DhyCKWNsKb+n/vMqLOGICgSqxWuXZs+eajBf9uVOgk5QfNvTY/mx0QSqYxkcz802dw==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
+          "integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
           "dev": true,
           "requires": {
             "elliptic": "^6.5.2",
@@ -16208,9 +16818,9 @@
       }
     },
     "libp2p-tcp": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.4.tgz",
-      "integrity": "sha512-7oU1ACrK6j5m3A08hrL7Ad0901shfljDtEk1Jdj3JWfQbUvvOIj8lzXUpMtwGZrNY5ar1gVCrH3zyHa4xohINw==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.5.tgz",
+      "integrity": "sha512-BLTtCe7jMYCfzrY1j4KAa3iByMZD5fgkH1bQ0WNCn/ye3w5mDemEgOT6+4p8/wuv2e0QXldGRB/DHUqB8lyNFw==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
@@ -16462,16 +17072,6 @@
         "p-timeout": "^3.2.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -16734,12 +17334,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
       "dev": true
     },
     "lodash.ismatch": {
@@ -18241,16 +18835,6 @@
             "readable-stream": "^3.4.0"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -19230,9 +19814,9 @@
       }
     },
     "p-queue": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.3.0.tgz",
-      "integrity": "sha512-fg5dJlFpd5+3CgG3/0ogpVZUeJbjiyXFg0nu53hrOYsybqSiDyxyOpad0Rm6tAiGjgztAwkyvhlYHC53OiAJOA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.4.0.tgz",
+      "integrity": "sha512-X7ddxxiQ+bLR/CUt3/BVKrGcJDNxBr0pEEFKHHB6vTPWNUhgDv36GpIH18RmGM3YGPpBT+JWGjDDqsVGuF0ERw==",
       "dev": true,
       "requires": {
         "eventemitter3": "^4.0.0",
@@ -19266,9 +19850,9 @@
       }
     },
     "p-settle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.0.1.tgz",
-      "integrity": "sha512-/9fOVH7ipE/TSaxHLZ95XklVLaX2rlOcocE17N/YARHaFbdKwf0jDnIVW22MVQ8sn3AjuJ0XIwylg6GZ3Lhg6Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.0.tgz",
+      "integrity": "sha512-4SdSDDOsf9QEigsscXuddUBv2V8H+a823JGndXpoDeosL1Ah1da8YSGMF5EZcfih6toY1+kFdmKQ87+bGVmwqQ==",
       "dev": true,
       "requires": {
         "p-limit": "^2.2.2",
@@ -20284,16 +20868,6 @@
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
             "readable-stream": "^3.4.0"
-          }
-        },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
           }
         },
         "debug": {
@@ -23443,12 +24017,21 @@
       "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "varint-decoder": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.1.1.tgz",
-      "integrity": "sha1-YT1i8HHX51dqIO/RbvTB4zWg3f0=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.4.0.tgz",
+      "integrity": "sha512-1TGstvah6UbxTJCKMNV9eqR3u8lP7R3zmF52/sXQGyUYbHhh5HxW2dMEGADkuboqrCgOgheBn+z02YvN4bYGFg==",
       "dev": true,
       "requires": {
+        "is-buffer": "^2.0.4",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
       }
     },
     "varuint-bitcoin": {

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
   },
   "contributors": [],
   "devDependencies": {
-    "go-ipfs-dep": "0.4.23-3",
-    "ipfs": "^0.43.0",
+    "go-ipfs-dep": "^0.5.0",
+    "ipfs": "^0.44.0",
     "ipfs-http-client": "^44.0.0"
   },
   "peerDependencies": {
-    "go-ipfs-dep": "^0.4.23-3",
-    "ipfs": "^0.43.0",
+    "go-ipfs-dep": "^0.5.0",
+    "ipfs": "^0.44.0",
     "ipfs-http-client": "^44.0.0"
   }
 }


### PR DESCRIPTION
Should probably have been part of #113?

Also uses the latest js-ipfs.