### PR TITLE
chore: add gossipsub grafting delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14500,8 +14500,7 @@
     "it-drain": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.1.tgz",
-      "integrity": "sha512-4aX8AsJWjRh0inNXGLa90fvxuB7vQY70WFasvskUMtpXXz8+MUH8R7PODBtn4yXCJ25ud2iRwWwa1g8DRDbrlA==",
-      "dev": true
+      "integrity": "sha512-4aX8AsJWjRh0inNXGLa90fvxuB7vQY70WFasvskUMtpXXz8+MUH8R7PODBtn4yXCJ25ud2iRwWwa1g8DRDbrlA=="
     },
     "it-first": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "is-os": "^1.0.1",
     "it-all": "^1.0.1",
     "it-concat": "^1.0.0",
+    "it-drain": "^1.0.1",
     "it-last": "^1.0.1",
     "libp2p-webrtc-star": "^0.17.9",
     "mocha": "^7.1.1",

--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -109,7 +109,6 @@ const subscribeToReceiveByPubsub = async (nodeA, nodeB, idA, idB) => {
   await waitForPeerToSubscribe(nodeB.api, topic)
   await nodeB.api.pubsub.subscribe(topic, checkMessage)
   await waitForNotificationOfSubscription(nodeA.api, topic, idB)
-  await delay(20000) // FIXME: gossipsub need this delay https://github.com/libp2p/go-libp2p-pubsub/issues/331
   const res1 = await nodeA.api.name.publish(ipfsRef, { resolve: false })
   await waitFor(() => subscribed === true, (50 * 1000))
   const res2 = await last(nodeB.api.name.resolve(idA))

--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -109,7 +109,7 @@ const subscribeToReceiveByPubsub = async (nodeA, nodeB, idA, idB) => {
   await waitForPeerToSubscribe(nodeB.api, topic)
   await nodeB.api.pubsub.subscribe(topic, checkMessage)
   await waitForNotificationOfSubscription(nodeA.api, topic, idB)
-  await delay(10000) // FIXME: gossipsub need this delay https://github.com/libp2p/go-libp2p-pubsub/issues/331
+  await delay(20000) // FIXME: gossipsub need this delay https://github.com/libp2p/go-libp2p-pubsub/issues/331
   const res1 = await nodeA.api.name.publish(ipfsRef, { resolve: false })
   await waitFor(() => subscribed === true, (50 * 1000))
   const res2 = await last(nodeB.api.name.resolve(idA))

--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -6,6 +6,7 @@ const base64url = require('base64url')
 const ipns = require('ipns')
 const delay = require('delay')
 const last = require('it-last')
+const drain = require('it-drain')
 const pRetry = require('p-retry')
 const waitFor = require('./utils/wait-for')
 const { expect } = require('./utils/chai')
@@ -15,21 +16,23 @@ const daemonsOptions = {
   args: ['--enable-namesys-pubsub'] // enable ipns over pubsub
 }
 
-const retryOptions = {
-  retries: 5
-}
-
 const namespace = '/record/'
 
 const ipfsRef = '/ipfs/QmPFVLPmp9zv5Z5KUqLhe2EivAGccQW2r7M7jhVJGLZoZU'
 
 describe('ipns-pubsub', function () {
   this.timeout(350 * 1000)
-  let nodes = []
+  let go
+  let js
+  let otherGo
 
   // Spawn daemons
   before(async function () {
-    nodes = await Promise.all([
+    [
+      go,
+      js,
+      otherGo
+    ] = await Promise.all([
       daemonFactory.spawn({
         type: 'go',
         test: true,
@@ -52,11 +55,11 @@ describe('ipns-pubsub', function () {
 
   // Connect nodes and wait for republish
   before(async function () {
-    await nodes[0].api.swarm.connect(nodes[1].api.peerId.addresses[0])
+    await go.api.swarm.connect(js.api.peerId.addresses[0])
 
     // TODO: go-ipfs needs two nodes in the DHT to be able to publish a record
     // Remove this when js-ipfs has a DHT
-    await nodes[0].api.swarm.connect(nodes[2].api.peerId.addresses[0])
+    await go.api.swarm.connect(otherGo.api.peerId.addresses[0])
 
     console.log('wait for republish as we can receive the republish message first') // eslint-disable-line
     await delay(60000)
@@ -65,7 +68,7 @@ describe('ipns-pubsub', function () {
   after(() => daemonFactory.clean())
 
   it('should get enabled state of pubsub', async function () {
-    for (const node of nodes) {
+    for (const node of [js, go]) {
       const state = await node.api.name.pubsub.state()
       expect(state).to.exist()
       expect(state.enabled).to.equal(true)
@@ -75,14 +78,14 @@ describe('ipns-pubsub', function () {
   it('should publish the received record to a go node and a js subscriber should receive it', async function () {
     this.timeout(300 * 1000)
     // TODO find out why JS doesn't resolve, might be just missing a DHT
-    await expect(last(nodes[1].api.name.resolve(nodes[0].api.peerId.id, { stream: false }))).to.eventually.be.rejected.with(/was not found in the network/)
-    await subscribeToReceiveByPubsub(nodes[0], nodes[1], nodes[0].api.peerId.id, nodes[1].api.peerId.id)
+    await expect(last(js.api.name.resolve(go.api.peerId.id, { stream: false }))).to.eventually.be.rejected.with(/was not found in the network/)
+    await subscribeToReceiveByPubsub(go, js, go.api.peerId.id, js.api.peerId.id)
   })
 
   it('should publish the received record to a js node and a go subscriber should receive it', async function () {
     this.timeout(350 * 1000)
-    await last(nodes[0].api.name.resolve(nodes[1].api.peerId.id, { stream: false }))
-    await subscribeToReceiveByPubsub(nodes[1], nodes[0], nodes[1].api.peerId.id, nodes[0].api.peerId.id)
+    await drain(go.api.name.resolve(js.api.peerId.id, { stream: false }))
+    await subscribeToReceiveByPubsub(js, go, js.api.peerId.id, go.api.peerId.id)
   })
 })
 
@@ -106,6 +109,7 @@ const subscribeToReceiveByPubsub = async (nodeA, nodeB, idA, idB) => {
   await waitForPeerToSubscribe(nodeB.api, topic)
   await nodeB.api.pubsub.subscribe(topic, checkMessage)
   await waitForNotificationOfSubscription(nodeA.api, topic, idB)
+  await delay(10000) // FIXME: gossipsub need this delay https://github.com/libp2p/go-libp2p-pubsub/issues/331
   const res1 = await nodeA.api.name.publish(ipfsRef, { resolve: false })
   await waitFor(() => subscribed === true, (50 * 1000))
   const res2 = await last(nodeB.api.name.resolve(idA))
@@ -115,23 +119,29 @@ const subscribeToReceiveByPubsub = async (nodeA, nodeB, idA, idB) => {
 }
 
 // wait until a peer know about other peer to subscribe a topic
-const waitForNotificationOfSubscription = (daemon, topic, peerId) => pRetry(async () => {
-  const res = await daemon.pubsub.peers(topic)
+const waitForNotificationOfSubscription = async (daemon, topic, peerId) => {
+  const start = Date.now()
 
-  if (!res || !res.length || !res.includes(peerId)) {
-    throw new Error('Could not find peer subscribing')
-  }
-}, retryOptions)
+  await pRetry(async (attempt) => {
+    const res = await daemon.pubsub.peers(topic)
+
+    if (!res.includes(peerId)) {
+      throw new Error(`Could not find peer ${peerId} subscription in list ${res} after ${attempt} retries and ${Date.now() - start}ms`)
+    }
+  })
+}
 
 // Wait until a peer subscribes a topic
 const waitForPeerToSubscribe = async (daemon, topic) => {
-  await pRetry(async () => {
+  const start = Date.now()
+
+  await pRetry(async (attempt) => {
     const res = await daemon.pubsub.ls()
 
-    if (!res || !res.length || !res.includes(topic)) {
-      throw new Error('Could not find subscription')
+    if (!res.includes(topic)) {
+      throw new Error(`Could not find subscription to ${topic} in ${res} after ${attempt} retries and ${Date.now() - start}ms`)
     }
 
     return res[0]
-  }, retryOptions)
+  })
 }

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -5,7 +5,6 @@
 const pRetry = require('p-retry')
 const { expect } = require('./utils/chai')
 const daemonFactory = require('./utils/daemon-factory')
-const delay = require('delay')
 
 const waitForTopicPeer = (topic, peer, daemon) => {
   const start = Date.now()
@@ -82,7 +81,6 @@ describe('pubsub', function () {
         const publisher = async () => {
           await waitForTopicPeer(topic, daemon1.api.peerId, daemon2)
           await waitForTopicPeer(topic, daemon2.api.peerId, daemon1)
-          await delay(20000) // FIXME: https://github.com/libp2p/go-libp2p-pubsub/issues/331
           await daemon1.api.pubsub.publish(topic, data)
         }
 

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -82,7 +82,7 @@ describe('pubsub', function () {
         const publisher = async () => {
           await waitForTopicPeer(topic, daemon1.api.peerId, daemon2)
           await waitForTopicPeer(topic, daemon2.api.peerId, daemon1)
-          await delay(10000) // FIXME: https://github.com/libp2p/go-libp2p-pubsub/issues/331
+          await delay(20000) // FIXME: https://github.com/libp2p/go-libp2p-pubsub/issues/331
           await daemon1.api.pubsub.publish(topic, data)
         }
 


### PR DESCRIPTION
Because of https://github.com/libp2p/go-libp2p-pubsub/issues/331 we have to wait for a the gossipsub peer to become grafted before sending messages we expect to be received.  There's no way to tell from the API which peers are grafted so we just have to add an arbitrary wait and hope it happens during that time window.

Also refactors the pubsub tests to remove duplicated code and the ipns-pubsub tests to use named variables instead of array indices for readability.