### PR TITLE
refactor: ipfs.add only works on single items

### DIFF
--- a/test/cid-version-agnostic.js
+++ b/test/cid-version-agnostic.js
@@ -2,7 +2,6 @@
 'use strict'
 
 const { nanoid } = require('nanoid')
-const last = require('it-last')
 const concat = require('it-concat')
 const { expect } = require('./utils/chai')
 const daemonFactory = require('./utils/daemon-factory')
@@ -34,7 +33,7 @@ describe('CID version agnostic', function () {
 
   it('should add v0 and cat v1 (go0 -> go0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.go0.api.add(input, { cidVersion: 0 }))
+    const { cid } = await daemons.go0.api.add(input, { cidVersion: 0 })
     const cidv1 = cid.toV1()
     const output = await concat(daemons.go0.api.cat(cidv1))
     expect(output.slice()).to.deep.equal(input)
@@ -42,7 +41,7 @@ describe('CID version agnostic', function () {
 
   it('should add v0 and cat v1 (js0 -> js0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.js0.api.add(input, { cidVersion: 0 }))
+    const { cid } = await daemons.js0.api.add(input, { cidVersion: 0 })
     const cidv1 = cid.toV1()
     const output = await concat(daemons.js0.api.cat(cidv1))
     expect(output.slice()).to.deep.equal(input)
@@ -50,7 +49,7 @@ describe('CID version agnostic', function () {
 
   it('should add v0 and cat v1 (go0 -> go1)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.go0.api.add(input, { cidVersion: 0 }))
+    const { cid } = await daemons.go0.api.add(input, { cidVersion: 0 })
     const cidv1 = cid.toV1()
     const output = await concat(daemons.go1.api.cat(cidv1))
     expect(output.slice()).to.deep.equal(input)
@@ -58,7 +57,7 @@ describe('CID version agnostic', function () {
 
   it('should add v0 and cat v1 (js0 -> js1)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.js0.api.add(input, { cidVersion: 0 }))
+    const { cid } = await daemons.js0.api.add(input, { cidVersion: 0 })
     const cidv1 = cid.toV1()
     const output = await concat(daemons.js1.api.cat(cidv1))
     expect(output.slice()).to.deep.equal(input)
@@ -66,7 +65,7 @@ describe('CID version agnostic', function () {
 
   it('should add v0 and cat v1 (js0 -> go0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.js0.api.add(input, { cidVersion: 0 }))
+    const { cid } = await daemons.js0.api.add(input, { cidVersion: 0 })
     const cidv1 = cid.toV1()
     const output = await concat(daemons.go0.api.cat(cidv1))
     expect(output.slice()).to.deep.equal(input)
@@ -74,7 +73,7 @@ describe('CID version agnostic', function () {
 
   it('should add v0 and cat v1 (go0 -> js0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.go0.api.add(input, { cidVersion: 0 }))
+    const { cid } = await daemons.go0.api.add(input, { cidVersion: 0 })
     const cidv1 = cid.toV1()
     const output = await concat(daemons.js0.api.cat(cidv1))
     expect(output.slice()).to.deep.equal(input)
@@ -82,7 +81,7 @@ describe('CID version agnostic', function () {
 
   it('should add v1 and cat v0 (go0 -> go0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.go0.api.add(input, { cidVersion: 1, rawLeaves: false }))
+    const { cid } = await daemons.go0.api.add(input, { cidVersion: 1, rawLeaves: false })
     const cidv0 = cid.toV0()
     const output = await concat(daemons.go0.api.cat(cidv0))
     expect(output.slice()).to.deep.equal(input)
@@ -90,7 +89,7 @@ describe('CID version agnostic', function () {
 
   it('should add v1 and cat v0 (js0 -> js0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.js0.api.add(input, { cidVersion: 1, rawLeaves: false }))
+    const { cid } = await daemons.js0.api.add(input, { cidVersion: 1, rawLeaves: false })
     const cidv0 = cid.toV0()
     const output = await concat(daemons.js0.api.cat(cidv0))
     expect(output.slice()).to.deep.equal(input)
@@ -98,7 +97,7 @@ describe('CID version agnostic', function () {
 
   it('should add v1 and cat v0 (go0 -> go1)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.go0.api.add(input, { cidVersion: 1, rawLeaves: false }))
+    const { cid } = await daemons.go0.api.add(input, { cidVersion: 1, rawLeaves: false })
     const cidv0 = cid.toV0()
     const output = await concat(daemons.go1.api.cat(cidv0))
     expect(output.slice()).to.deep.equal(input)
@@ -106,7 +105,7 @@ describe('CID version agnostic', function () {
 
   it('should add v1 and cat v0 (js0 -> js1)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.js0.api.add(input, { cidVersion: 1, rawLeaves: false }))
+    const { cid } = await daemons.js0.api.add(input, { cidVersion: 1, rawLeaves: false })
     const cidv0 = cid.toV0()
     const output = await concat(daemons.js1.api.cat(cidv0))
     expect(output.slice()).to.deep.equal(input)
@@ -114,7 +113,7 @@ describe('CID version agnostic', function () {
 
   it('should add v1 and cat v0 (js0 -> go0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.js0.api.add(input, { cidVersion: 1, rawLeaves: false }))
+    const { cid } = await daemons.js0.api.add(input, { cidVersion: 1, rawLeaves: false })
     const cidv0 = cid.toV0()
     const output = await concat(daemons.go0.api.cat(cidv0))
     expect(output.slice()).to.deep.equal(input)
@@ -122,7 +121,7 @@ describe('CID version agnostic', function () {
 
   it('should add v1 and cat v0 (go0 -> js0)', async () => {
     const input = Buffer.from(nanoid())
-    const { cid } = await last(daemons.go0.api.add(input, { cidVersion: 1, rawLeaves: false }))
+    const { cid } = await daemons.go0.api.add(input, { cidVersion: 1, rawLeaves: false })
     const cidv0 = cid.toV0()
     const output = await concat(daemons.js0.api.cat(cidv0))
     expect(output.slice()).to.deep.equal(input)

--- a/test/exchange-files.js
+++ b/test/exchange-files.js
@@ -13,7 +13,6 @@ const isCi = require('is-ci')
 const isWindows = require('is-os').isWindows
 const os = require('os')
 const rmDir = promisify(rimraf)
-const last = require('it-last')
 const concat = require('it-concat')
 const { globSource } = require(process.env.IPFS_JS_MODULE || 'ipfs')
 const { expect } = require('./utils/chai')
@@ -133,7 +132,7 @@ describe('exchange files', function () {
 
           const data = crypto.randomBytes(size)
 
-          const { cid } = await last(daemon1.api.add(data))
+          const { cid } = await daemon1.api.add(data)
           const file = await concat(daemon2.api.cat(cid))
 
           expect(file.slice()).to.eql(data)
@@ -155,7 +154,7 @@ describe('exchange files', function () {
               depth: d,
               number: num
             })
-            const { cid } = await last(daemon1.api.add(globSource(dir, { recursive: true })))
+            const { cid } = await daemon1.api.add(globSource(dir, { recursive: true }))
 
             let fileCount = 0
             for await (const file of daemon2.api.get(cid)) {

--- a/test/files.js
+++ b/test/files.js
@@ -226,9 +226,9 @@ describe('files', function () {
 
   describe('has the same hashes for', () => {
     const testHashesAreEqual = async (daemon, data, options = {}) => {
-      const files = await all(daemon.api.add(data, options))
+      const { cid } = await daemon.api.add(data, options)
 
-      return files[0].cid
+      return cid
     }
 
     const _writeData = async (daemon, initialData, newData, options) => {
@@ -417,7 +417,7 @@ describe('files', function () {
 
       // will operate on sub-shard three levels deep
       const testHamtShardHashesAreEqual = async (daemon, data) => {
-        const { cid } = await last(daemon.api.add(data))
+        const { cid } = await last(daemon.api.addAll(data))
 
         await daemon.api.files.cp(`/ipfs/${cid}`, dir)
 

--- a/test/kad-dht.js
+++ b/test/kad-dht.js
@@ -2,7 +2,6 @@
 'use strict'
 
 const crypto = require('crypto')
-const last = require('it-last')
 const concat = require('it-concat')
 const { expect } = require('./utils/chai')
 const daemonFactory = require('./utils/daemon-factory')
@@ -36,7 +35,7 @@ describe.skip('kad-dht', () => {
     it('one hop', async () => {
       const data = crypto.randomBytes(9001)
 
-      const { cid } = await last(goD1.api.add(data))
+      const { cid } = await goD1.api.add(data)
       const file = await concat(jsD.api.cat(cid))
 
       expect(file.slice()).to.be.eql(data)
@@ -45,7 +44,7 @@ describe.skip('kad-dht', () => {
     it('two hops', async () => {
       const data = crypto.randomBytes(9001)
 
-      const { cid } = await last(goD2.api.add(data))
+      const { cid } = await goD2.api.add(data)
       const file = await concat(jsD.api.cat(cid))
 
       expect(file.slice()).to.be.eql(data)
@@ -54,7 +53,7 @@ describe.skip('kad-dht', () => {
     it('three hops', async () => {
       const data = crypto.randomBytes(9001)
 
-      const { cid } = await last(goD3.api.add(data))
+      const { cid } = await goD3.api.add(data)
       const file = await concat(jsD.api.cat(cid))
 
       expect(file.slice()).to.be.eql(data)

--- a/test/repo.js
+++ b/test/repo.js
@@ -7,7 +7,6 @@ const path = require('path')
 const { nanoid } = require('nanoid')
 const delay = require('delay')
 const concat = require('it-concat')
-const last = require('it-last')
 const { expect } = require('./utils/chai')
 const daemonFactory = require('./utils/daemon-factory')
 
@@ -44,7 +43,7 @@ describe.skip('repo', function () {
     await goDaemon.init()
     await goDaemon.start()
 
-    const { cid } = await last(goDaemon.api.add(data))
+    const { cid } = await goDaemon.api.add(data)
 
     await catAndCheck(goDaemon.api, cid, data)
     await goDaemon.stop()
@@ -78,7 +77,7 @@ describe.skip('repo', function () {
     await jsDaemon.init()
     await jsDaemon.start()
 
-    const { cid } = await last(jsDaemon.api.add(data))
+    const { cid } = await jsDaemon.api.add(data)
 
     await catAndCheck(jsDaemon.api, cid, data)
     await jsDaemon.stop()

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -2,7 +2,6 @@
 
 const delay = require('delay')
 const crypto = require('crypto')
-const last = require('it-last')
 const concat = require('it-concat')
 const { expect } = require('./chai')
 const daemonFactory = require('./daemon-factory')
@@ -60,7 +59,7 @@ exports.clean = () => daemonFactory.clean()
 
 const data = crypto.randomBytes(128)
 exports.send = async (nodeA, nodeB) => {
-  const { cid } = await last(nodeA.api.add(data))
+  const { cid } = await nodeA.api.add(data)
   const buffer = await concat(nodeB.api.cat(cid))
 
   expect(buffer.slice()).to.deep.equal(data)


### PR DESCRIPTION
Refactors code to use ipfs.add for single item adds and ipfs.addAll
for multiple items.