### PR TITLE
test: reduce ipns pubsub test duration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2348,9 +2348,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
-      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -2411,6 +2411,15 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
+    "@types/bl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bl/-/bl-2.1.0.tgz",
+      "integrity": "sha512-1TdA9IXOy4sdqn8vgieQ6GZAiHiPNrOiO1s2GJjuYPw4QVY7gYoVjkW049avj33Ez7IcIvu43hQsMsoUFbCn2g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -2467,9 +2476,9 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/node": {
-      "version": "14.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw=="
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2482,9 +2491,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/pbkdf2": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.0.0.tgz",
-      "integrity": "sha512-6J6MHaAlBJC/eVMy9jOwj9oHaprfutukfW/Dyt0NEnpQ/6HN6YQrpvLwzWdWDeWZIdenjGHlbYDzyEODO5Z+2Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -2916,9 +2925,9 @@
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.1.tgz",
-      "integrity": "sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -4252,9 +4261,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001100",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001100.tgz",
-      "integrity": "sha512-0eYdp1+wFCnMlCj2oudciuQn2B9xAFq3WpgpcBIZTxk/1HNA/O2YA7rpeYhnOqsqAJq1AHUgx6i1jtafg7m2zA=="
+      "version": "1.0.30001107",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001107.tgz",
+      "integrity": "sha512-86rCH+G8onCmdN4VZzJet5uPELII59cUzDphko3thQFgAQG1RNa+sVLDoALIhRYmflo5iSIzWY3vu1XTWtNMQQ=="
     },
     "cb2promise": {
       "version": "1.1.1",
@@ -4560,9 +4569,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.3.0.tgz",
-      "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA=="
     },
     "cli-truncate": {
       "version": "0.2.1",
@@ -4675,9 +4684,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codecov": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.0.tgz",
-      "integrity": "sha512-uIixKofG099NbUDyzRk1HdGtaG8O+PBUAg3wfmjwXw2+ek+PZp+puRvbTohqrVfuudaezivJHFgTtSC3M8MXww==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.2.tgz",
+      "integrity": "sha512-fmCjAkTese29DUX3GMIi4EaKGflHa4K51EoMc29g8fBHawdk/+KEq5CWOeXLdd9+AT7o1wO4DIpp/Z1KCqCz1g==",
       "requires": {
         "argv": "0.0.2",
         "ignore-walk": "3.0.3",
@@ -6052,13 +6061,43 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "dag-cbor-links": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.4.tgz",
-      "integrity": "sha512-+4yAa3YQo4hucbdT+zsb/8nj5ZXsb4iIm/LzeUdUBv4zwfhR7Z5DJ1WNZTJvNh4XUO1fLOBRxCrlwnn5BqoNqg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.5.tgz",
+      "integrity": "sha512-yvNocHk61MIio/JpDta6/DUS7rxa7N4+uezf2u20hmLaMNA8meExbc8MvpJDEHYE9grbj+hkZnYOjNoaSXFX8A==",
       "dev": true,
       "requires": {
         "cids": "^0.8.0",
-        "ipld-dag-cbor": "^0.15.2"
+        "ipld-dag-cbor": "^0.16.0"
+      },
+      "dependencies": {
+        "ipld-dag-cbor": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
+          "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
+          "dev": true,
+          "requires": {
+            "borc": "^2.1.2",
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "is-circular": "^1.0.2",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "dargs": {
@@ -6357,9 +6396,9 @@
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delay": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
-      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
+      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -7210,9 +7249,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.498",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.498.tgz",
-      "integrity": "sha512-W1hGwaQEU8j9su2jeAr3aabkPuuXw+j8t73eajGAkEJWbfWiwbxBwQN/8Qmv2qCy3uCDm2rOAaZneYQM8VGC4w=="
+      "version": "1.3.512",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.512.tgz",
+      "integrity": "sha512-y02hdFg7c4jTfREcXf4fRhHLt7BzofMgd7JAKY+u9i62E0D1eIpLQPFo5/eboZL0bIVY9YHZA53+vCGNFREOXA=="
     },
     "electron-window": {
       "version": "0.8.1",
@@ -8176,9 +8215,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.1.tgz",
-      "integrity": "sha512-aVUPRLgmXORGXXEVkFYgPhr9TGtpBY2tGhZ9Uh0A3lIUzUDr1x6kQx33SbjPUkLkX3eniPQnIL/2psjkjrOfcQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
       "dev": true
     },
     "ethereumjs-tx": {
@@ -8241,9 +8280,9 @@
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -9012,9 +9051,9 @@
       }
     },
     "fromentries": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-      "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+      "integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -10773,9 +10812,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.18.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -11084,9 +11123,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.2.tgz",
-      "integrity": "sha512-DF4osh1FM6l0RJc5YWYhSDB6TawiBRlbV9Cox8MWlidU218Tb7fm3lQTULyUJDfJ0tjbzl0W4q651mrCCEM55w==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.0",
@@ -11094,7 +11133,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.16",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -11178,9 +11217,9 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.48.0.tgz",
-      "integrity": "sha512-sNz8qFSioV64l9yZyRFwH0rEyhlh0falksyEdRW4lVC5ebCRcNI5rzWvCzPhGw07P8hU+DAYiVz+8SLxUnuS0A==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.48.1.tgz",
+      "integrity": "sha512-olvmy0xQ2SFB1dd1CI/legZrzVSgU3avd7PFJG7f7d2KpKFjjwUAjBR9ucDxLqqSmUNhgcBZbfuwoY9R8MhFEw==",
       "dev": true,
       "requires": {
         "@hapi/ammo": "^3.1.2",
@@ -11212,7 +11251,7 @@
         "hapi-pino": "^6.1.0",
         "hashlru": "^2.3.0",
         "interface-datastore": "^1.0.2",
-        "ipfs-bitswap": "^2.0.0",
+        "ipfs-bitswap": "^2.0.1",
         "ipfs-block-service": "^0.17.1",
         "ipfs-core-utils": "^0.3.0",
         "ipfs-http-client": "^45.0.0",
@@ -11251,7 +11290,7 @@
         "just-safe-set": "^2.1.0",
         "libp2p": "^0.28.5",
         "libp2p-bootstrap": "^0.11.0",
-        "libp2p-crypto": "^0.17.6",
+        "libp2p-crypto": "^0.17.8",
         "libp2p-delegated-content-routing": "^0.5.0",
         "libp2p-delegated-peer-routing": "^0.5.0",
         "libp2p-floodsub": "^0.21.0",
@@ -11353,15 +11392,15 @@
       }
     },
     "ipfs-bitswap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-2.0.0.tgz",
-      "integrity": "sha512-wt0jCRtESZPxfQE3r6c4SlSDjfiZOU+eqaaBMQ/dIGgaHPnLDBniII+kybcaGV5EifcGkMGQ+X7CnMmpWsKhOQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-2.0.1.tgz",
+      "integrity": "sha512-kZauF0XwatrMe0SfdKs4abrarcVNRzdfWFaz+kodGl1Uq7aryf/DZmSutw3NFkJDVnYWAQ7l55VsDRxC4kD6dg==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
-        "cids": "~0.8.0",
+        "cids": "^0.8.3",
         "debug": "^4.1.0",
         "ipld-block": "^0.9.1",
         "it-length-prefixed": "^3.0.0",
@@ -11369,10 +11408,10 @@
         "just-debounce-it": "^1.1.0",
         "libp2p-interfaces": "^0.3.0",
         "moving-average": "^1.0.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "^0.8.0",
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0",
         "protons": "^1.0.1",
-        "streaming-iterables": "^4.1.1",
+        "streaming-iterables": "^5.0.2",
         "varint-decoder": "^0.4.0"
       },
       "dependencies": {
@@ -11389,6 +11428,26 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "streaming-iterables": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.2.tgz",
+          "integrity": "sha512-9z5iBWe9WXzdT0X1JT9fVC0mCcVxWt5yzZMBUIgjZnt2k23+UQF8Ac6kiI8DnlYZJn5iysvxKl3uGzlijMQ+/g==",
           "dev": true
         }
       }
@@ -11727,79 +11786,93 @@
       }
     },
     "ipld": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.3.tgz",
-      "integrity": "sha512-x6Udh4LVMerZduKk0eRNOhBKJeZwQgZ1YIH9AR7E5RjRJ0cPqEpq43DGbiHhU5XOXjBQiwdJwX5p9pxxiKkG9Q==",
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.4.tgz",
+      "integrity": "sha512-beRa9tayJDbzlqA7UEnUXQq654dAgnsrTSIJIe/vOBJToH8lDc/pLuIOmPYrDCVlv6XtJuZ7qgk3bIPppb21dA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "~0.8.0",
-        "ipld-block": "~0.9.1",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.18.1",
+        "cids": "^0.8.3",
+        "ipld-block": "^0.9.1",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
         "ipld-raw": "^5.0.0",
         "merge-options": "^2.0.0",
         "multicodec": "^1.0.0",
         "typical": "^6.0.0"
+      },
+      "dependencies": {
+        "ipld-dag-cbor": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
+          "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
+          "dev": true,
+          "requires": {
+            "borc": "^2.1.2",
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "is-circular": "^1.0.2",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0",
+            "protons": "^1.2.1",
+            "stable": "^0.1.8"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-bitcoin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.1.tgz",
-      "integrity": "sha512-0ysHoWyT+xXNyDafZrlH6YHGXWKkZ392eOardFTl2c9EUXDOt2W8VNaWol8ZyYSlD1nELwNLjC4e7p8aBY/OEg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.2.tgz",
+      "integrity": "sha512-cglP2KmfpQK6UWR6Yu4+F2Aj8z5m3z/ng4Bq2FV9rxASGSQn1nmVRFQu39j2lYcEUrvPPc+HRsDz1Ppvd6xODQ==",
       "dev": true,
       "requires": {
         "bitcoinjs-lib": "^5.0.0",
-        "cids": "~0.7.0",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "multicodec": "^1.0.0",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.8.0"
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0"
       },
       "dependencies": {
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        },
-        "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
@@ -11845,81 +11918,67 @@
       }
     },
     "ipld-ethereum": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-4.0.1.tgz",
-      "integrity": "sha512-okaDApIYUpuSE/eJuYAhZsXzGJZrgY4nUPeESBWz/jNlhIAj2ZjDLjRcqL0mobsFPOww9+ml1Y96V8VsXOoXqg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-4.0.2.tgz",
+      "integrity": "sha512-0uShqn7PcCgWca7lkn8WE8sS8GVDxoi7+juiSLw2MApx+r11hPBjiMDKy0SFZoyXMRYPZA6Xh1WTqzH8UM2eHA==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.0",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "ethereumjs-account": "^3.0.0",
         "ethereumjs-block": "^2.2.1",
         "ethereumjs-tx": "^2.1.1",
         "merkle-patricia-tree": "^3.0.0",
         "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15",
-        "multihashing-async": "~0.8.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0",
         "rlp": "^2.2.4"
       },
       "dependencies": {
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        },
-        "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
     },
     "ipld-git": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.2.tgz",
-      "integrity": "sha512-mmBKquF1GZ6PcQdwylAgyhDQluPNzBVMI+20ddMjUdNH74AYO444xPA1Xb9Owi9ZYd37L6+okTN8sDl9dccpWA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.3.tgz",
+      "integrity": "sha512-ffJgkGFb7VnTh8AOZNu19de1pXecbInJ62iEfL1ydn330tgwWtSMI2ny2EXGuOg1LvR9DF87Shz92CdtW4zYTw==",
       "dev": true,
       "requires": {
-        "cids": "^0.8.2",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "multicodec": "^1.0.2",
-        "multihashing-async": "^0.8.1",
+        "multihashing-async": "^1.0.0",
         "smart-buffer": "^4.1.0",
         "strftime": "^0.10.0"
+      },
+      "dependencies": {
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-raw": {
@@ -11934,62 +11993,31 @@
       }
     },
     "ipld-zcash": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.4.1.tgz",
-      "integrity": "sha512-1JNnY0HuLeJDzlRJSKxs8laZ+TKPr8zui7GNiJMHgMIjH7KOiVjAQfO7Rt7KzDucMLYPokarfIPaK3qeffwI2A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.4.3.tgz",
+      "integrity": "sha512-HBczqYbhRWOGmq4kcLnD9W8sM5BBJPGTH/hHia4b97BpF1JYDCu+vDv8xrJUAj6l+o+VX4xs+S50tMMEDEhXXA==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.1",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15",
-        "multihashing-async": "~0.8.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0",
         "zcash-block": "^2.0.0"
       },
       "dependencies": {
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        },
-        "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
@@ -12842,11 +12870,12 @@
       "integrity": "sha512-zjWiVvkDXKxGA+u2ZNzq321RWnj52RLucsIX0Bve3NUX3X/b1RjtUufvUdjtkFtQLKG1yCf5+hxbdeIYiRT1rQ=="
     },
     "it-length-prefixed": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-3.0.1.tgz",
-      "integrity": "sha512-QnfnFkpklDhWpyPQ2al6pdqmsQbwZAUpa7066e8S9RQxXo0s4o21ceqCG0n/0wdmvgfRSYsW5g2dYgchqtLZYw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-3.1.0.tgz",
+      "integrity": "sha512-E5GwT6qfZEwh3/XThyYwgjKJ4/hxvTC9kdbj3gxXDeUDKtC7+K2T647sPeX7xDEWqunsnoQyvOrjoHPegaT3uw==",
       "dev": true,
       "requires": {
+        "@types/bl": "^2.1.0",
         "bl": "^4.0.2",
         "buffer": "^5.5.0",
         "varint": "^5.0.0"
@@ -13291,9 +13320,9 @@
       }
     },
     "karma": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-5.1.0.tgz",
-      "integrity": "sha512-I3aPbkuIbwuBo6wSog97P5WnnhCgUTsWTu/bEw1vZVQFbXmKO3PK+cfFhZioOgVtJAuQxoyauGNjnwXNHMCxbw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-5.1.1.tgz",
+      "integrity": "sha512-xAlOr5PMqUbiKXSv5PCniHWV3aiwj6wIZ0gUVcwpTCPVQm/qH2WAMFWxtnpM6KJqhkRWrIpovR4Rb0rn8GtJzQ==",
       "requires": {
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
@@ -13539,9 +13568,9 @@
       }
     },
     "keccak": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.0.tgz",
-      "integrity": "sha512-/4h4FIfFEpTEuySXi/nVFM5rqSKPnnhI7cL4K3MFSwoI3VyM7AhPSq3SsysARtnEBEeIKMBUWD8cTh9nHE8AkA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
       "dev": true,
       "requires": {
         "node-addon-api": "^2.0.0",
@@ -13897,9 +13926,9 @@
       }
     },
     "libp2p": {
-      "version": "0.28.7",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.28.7.tgz",
-      "integrity": "sha512-Qbi63RYtuxBSMKRNt4RsaYbjJIQTqyx1fTAMQrJZ0ofGRN0WvIvi1tL5FA3ElU3OXuKdX1myOFZWjbM+Mygkfw==",
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.28.9.tgz",
+      "integrity": "sha512-lvCfKm8MvOKm4qC+ZoEA93QJybOrcO/j2nuvAiruk4cys3BRn04SXjf48p7clST+US/MSuv77+R1fgwoXLOzRQ==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -13919,7 +13948,7 @@
         "it-length-prefixed": "^3.0.1",
         "it-pipe": "^1.1.0",
         "it-protocol-buffers": "^0.2.0",
-        "libp2p-crypto": "^0.17.6",
+        "libp2p-crypto": "^0.17.8",
         "libp2p-interfaces": "^0.3.1",
         "libp2p-utils": "^0.1.2",
         "mafmt": "^7.0.0",
@@ -13988,9 +14017,9 @@
       }
     },
     "libp2p-crypto": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.7.tgz",
-      "integrity": "sha512-z5Vkser8oGKsF8MAWovmXtFnEG7PqsgxrIgdSDejs2N6X+g3hUKFtxL/sKZpWD3tlLywcH9wqoE9L096ExB1lA==",
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.8.tgz",
+      "integrity": "sha512-jm5k4oqgV8NX9so65meWBkGC5bk6zvXyXWZKKUcnQcHHKnHUhuhIopSxIoBi5MDOrI1iLxn19+YOBFgSHkSaiA==",
       "requires": {
         "buffer": "^5.5.0",
         "err-code": "^2.0.0",
@@ -14490,19 +14519,19 @@
       }
     },
     "libp2p-tcp": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.5.tgz",
-      "integrity": "sha512-BLTtCe7jMYCfzrY1j4KAa3iByMZD5fgkH1bQ0WNCn/ye3w5mDemEgOT6+4p8/wuv2e0QXldGRB/DHUqB8lyNFw==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.6.tgz",
+      "integrity": "sha512-DeOdaH5QGVMKZflJmZq3dSWROxzD/YU1MFDxfi+DT4JVMcxfVMd+SpVEPMyk2wyA28H4AdGIRsH78yPjlFIyZQ==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "libp2p-utils": "~0.1.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "stream-to-it": "^0.2.0"
+        "libp2p-utils": "^0.1.2",
+        "mafmt": "^7.1.0",
+        "multiaddr": "^7.5.0",
+        "stream-to-it": "^0.2.2"
       },
       "dependencies": {
         "debug": {
@@ -14907,9 +14936,9 @@
       }
     },
     "loady": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.1.tgz",
-      "integrity": "sha512-PW5Z13Jd0v6ZcA1P6ZVUc3EV8BJwQuAiwUvvT6VQGHoaZ1d/tu7r1QZctuKfQqwy9SFBWeAGfcIdLxhp7ZW3Rw==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==",
       "dev": true
     },
     "locate-path": {
@@ -15809,9 +15838,9 @@
       }
     },
     "minipass-pipeline": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.3.tgz",
-      "integrity": "sha512-cFOknTvng5vqnwOpDsZTWhNll6Jf8o2x+/diplafmxpuIymAjzoOolZG0VvQf3V2HgqzJNhnuKHYp2BqDgz8IQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -16364,9 +16393,9 @@
       }
     },
     "multicodec": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.3.tgz",
-      "integrity": "sha512-8G4JKbHWSe/39Xx2uiI+/b/S6mGgimzwEN4TOCokFUIfofg1T8eHny88ht9eWImD2dng+EEQRsApXxA5ubhU4g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
       "requires": {
         "buffer": "^5.6.0",
         "varint": "^5.0.0"
@@ -16487,9 +16516,9 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanoid": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.10.tgz",
-      "integrity": "sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w=="
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.11.tgz",
+      "integrity": "sha512-HyrIRpCB2uS1/sEoS7/UIAM/Jn72uXf2/yWgQRP0e16/UdMsfH/1JyLj2SqyQlkMkeeN1ad61tpT6FPRRimxnA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16610,9 +16639,9 @@
       "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "node-gyp-build": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
-      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -16670,9 +16699,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.59",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
-      "integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw=="
+      "version": "1.1.60",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA=="
     },
     "nodeify": {
       "version": "1.0.1",
@@ -17091,9 +17120,9 @@
       }
     },
     "ora": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
-      "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.5.tgz",
+      "integrity": "sha512-jCDgm9DqvRcNIAEv2wZPrh7E5PcQiDUnbnWbAfu4NGAE2ZNqPFbDixmWldy1YG2QfLeQhuiu6/h5VRrk6cG50w==",
       "requires": {
         "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
@@ -17259,9 +17288,9 @@
       }
     },
     "p-queue": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.5.0.tgz",
-      "integrity": "sha512-FLaTTD9Am6TeDfNuN0d+INeyVJoICoBS+OVP5K1S84v4w51LN3nRkCT+WC7xLBepV2s+N4LibM7Ys7xcSc0+1A==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.0.tgz",
+      "integrity": "sha512-zPHXPNy9jZsiym0PpJjvnHQysx1fSd/QdaNVwiDRLU2KFChD6h9CkCB6b8i3U8lBwJyA+mHgNZCzcy77glUssQ==",
       "dev": true,
       "requires": {
         "eventemitter3": "^4.0.4",
@@ -17476,9 +17505,9 @@
       "dev": true
     },
     "parse-json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+      "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -18153,9 +18182,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.27",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
-          "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg==",
+          "version": "10.17.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
           "dev": true
         }
       }
@@ -18308,9 +18337,9 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "queue-microtask": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.3.tgz",
-      "integrity": "sha512-zC1ZDLKFhZSa8vAdFbkOGouHcOUMgUAI/2/3on/KktpY+BaVqABkzDSsCSvJfmLbICOnrEuF9VIMezZf+T0mBA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
     },
     "quick-format-unescaped": {
       "version": "3.0.3",
@@ -18746,9 +18775,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -19223,9 +19252,9 @@
       "dev": true
     },
     "secp256k1": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
-      "integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "requires": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -19437,12 +19466,12 @@
       }
     },
     "simple-git": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.12.0.tgz",
-      "integrity": "sha512-64YrHYqHskWDumxM4thMGCkAd7rek4FEnxcugnpKzJZH6vCkietblsp7TUNdt9qU0pHAnJAanAmjyyQLE46k/Q==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.15.0.tgz",
+      "integrity": "sha512-a1IE3q8pWsGhQR0/ugAkXls2ekbB7LDhJnFnrS/R+5zFZZbN4bfdIp3Vdht4x/z1oIH/8IHiKdjilN55FGL70g==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.0.1",
+        "@kwsites/promise-deferred": "^1.1.1",
         "debug": "^4.1.1"
       },
       "dependencies": {
@@ -20249,32 +20278,14 @@
       "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164="
     },
     "strtok3": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.3.tgz",
-      "integrity": "sha512-/3RaYN9rW5WEYNHSvn081CgL4HziT027hfi5tsksbPfeWxi3BSLb8tolZDzpYU3I78/0ZqRiFpMDAqN2t4YShA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
+      "integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
       "dev": true,
       "requires": {
         "@tokenizer/token": "^0.1.1",
         "@types/debug": "^4.1.5",
-        "debug": "^4.1.1",
         "peek-readable": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "stubs": {
@@ -20548,14 +20559,14 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.0.6.tgz",
-      "integrity": "sha512-z3HLOOPUHkCNGkeEHqqiMAIy1pjpHwS1o+i6Zn0Ws3EAvHJj46737efNNEvJ0Vx9BdDQM83d56qySDJOSORA0A==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.0.8.tgz",
+      "integrity": "sha512-ygwK8TYMRTYtSyLB2Mhnt90guQh989CIq/mL/2apwi6rA15Xys4ydNUiH4ah6EZCfQxSk26ZFQilZ4IQ6IZw6A==",
       "requires": {
-        "cacache": "^15.0.4",
+        "cacache": "^15.0.5",
         "find-cache-dir": "^3.3.1",
-        "jest-worker": "^26.0.0",
-        "p-limit": "^3.0.1",
+        "jest-worker": "^26.1.0",
+        "p-limit": "^3.0.2",
         "schema-utils": "^2.6.6",
         "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
@@ -21694,11 +21705,11 @@
       }
     },
     "watchpack": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-      "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "requires": {
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
         "watchpack-chokidar2": "^2.0.0"
@@ -21832,9 +21843,9 @@
       }
     },
     "webpack": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-      "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.0.tgz",
+      "integrity": "sha512-wAuJxK123sqAw31SpkPiPW3iKHgFUiKvO7E7UZjtdExcsRe3fgav4mvoMM7vvpjLHVoJ6a0Mtp2fzkoA13e0Zw==",
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",
@@ -21844,7 +21855,7 @@
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
+        "enhanced-resolve": "^4.3.0",
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",
@@ -21857,7 +21868,7 @@
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
         "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.1",
+        "watchpack": "^1.7.4",
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {

--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -111,7 +111,7 @@ const subscribeToReceiveByPubsub = async (nodeA, nodeB, idA, idB) => {
   await waitFor(() => subscribed === true, (50 * 1000))
   const res2 = await last(nodeB.api.name.resolve(idA))
 
-  expect(PeerID.createFromCID(res1.name).toString()).to.equal(PeerID.createFromB58String(idA).toString()) // Published to Node A ID
+  expect(PeerID.createFromCID(res1.name).toString()).to.equal(PeerID.createFromCID(idA).toString()) // Published to Node A ID
   expect(res2).to.equal(ipfsRef)
 }
 

--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -27,8 +27,8 @@ describe('ipns-pubsub', function () {
   let nodes = []
 
   // Spawn daemons
-  before(async function () {
-    this.timeout(10e3)
+  before('create the nodes', async function () {
+    this.timeout(20e3)
     nodes = await Promise.all([
       daemonFactory.spawn({
         type: 'go',
@@ -51,7 +51,7 @@ describe('ipns-pubsub', function () {
   })
 
   // Connect nodes and wait for republish
-  before(async function () {
+  before('connect the nodes', async function () {
     this.timeout(10e3)
     // TODO: go-ipfs needs two nodes in the DHT to be able to publish a record
     // Remove the second connect when js-ipfs runs a DHT server

--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -24,7 +24,6 @@ const namespace = '/record/'
 const ipfsRef = '/ipfs/QmPFVLPmp9zv5Z5KUqLhe2EivAGccQW2r7M7jhVJGLZoZU'
 
 describe('ipns-pubsub', function () {
-  this.timeout(350 * 1000)
   let nodes = []
 
   // Spawn daemons
@@ -71,7 +70,6 @@ describe('ipns-pubsub', function () {
   })
 
   it('should publish the received record to a go node and a js subscriber should receive it', async function () {
-    this.timeout(300 * 1000)
     // TODO find out why JS doesn't resolve, might be just missing a DHT
     await Promise.all([
       subscribeToReceiveByPubsub(nodes[0], nodes[1], nodes[0].api.peerId.id, nodes[1].api.peerId.id),
@@ -80,7 +78,6 @@ describe('ipns-pubsub', function () {
   })
 
   it('should publish the received record to a js node and a go subscriber should receive it', async function () {
-    this.timeout(350 * 1000)
     await Promise.all([
       subscribeToReceiveByPubsub(nodes[1], nodes[0], nodes[1].api.peerId.id, nodes[0].api.peerId.id),
       last(nodes[0].api.name.resolve(nodes[1].api.peerId.id, { stream: false }))

--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -28,6 +28,7 @@ describe('ipns-pubsub', function () {
 
   // Spawn daemons
   before(async function () {
+    this.timeout(10e3)
     nodes = await Promise.all([
       daemonFactory.spawn({
         type: 'go',
@@ -51,6 +52,7 @@ describe('ipns-pubsub', function () {
 
   // Connect nodes and wait for republish
   before(async function () {
+    this.timeout(10e3)
     // TODO: go-ipfs needs two nodes in the DHT to be able to publish a record
     // Remove the second connect when js-ipfs runs a DHT server
     await Promise.all([


### PR DESCRIPTION
The `ipns-pubsub` tests were taking 2+ minutes to complete. There was a 60 second delay in the before test. I assume this was added previously due to some timing issues, but this isn't necessary. Additionally, I'm not sure why the ipns resolve statements were being done serially, this just adds to the test time (1 test regularly takes about 60s to complete, likely due to the republish interval but I'm not certain). 

This update removes the unnecessary delay in the `before` and lets the pubsub and regular resolve happen in parallel which **reduces the time by ~2mins**.

| **Before** | **After** |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/639834/88805511-87707e80-d1af-11ea-81d9-c4cb4c2be496.png) | ![image](https://user-images.githubusercontent.com/639834/88805252-319bd680-d1af-11ea-977c-dd0cc7f85ef5.png) |
