### PR TITLE
fix: disable pubsub until http rpc changes land

### DIFF
--- a/test/ipns-pubsub.js
+++ b/test/ipns-pubsub.js
@@ -22,7 +22,8 @@ const namespace = '/record/'
 
 const ipfsRef = '/ipfs/QmPFVLPmp9zv5Z5KUqLhe2EivAGccQW2r7M7jhVJGLZoZU'
 
-describe('ipns-pubsub', function () {
+// TODO: unskip after https://github.com/ipfs/js-ipfs/pull/3922 and https://github.com/ipfs/go-ipfs/pull/8183 both ship
+describe.skip('ipns-pubsub', function () {
   let nodes = []
   let factory
 

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -27,7 +27,8 @@ const daemonOptions = {
 
 const timeout = 20e3
 
-describe('pubsub', function () {
+// TODO: unskip after https://github.com/ipfs/js-ipfs/pull/3922 and https://github.com/ipfs/go-ipfs/pull/8183 both ship
+describe.skip('pubsub', function () {
   this.timeout(60 * 1000)
 
   const tests = {


### PR DESCRIPTION
This PR temporarily disables pubsub tests as we are unable to test interop until both JS and GO changes land:

- tests for new RPC wire format in pubsub commands are in https://github.com/ipfs/interop/pull/387 but landing that PR is blocked until we ship stable releases with:
  - https://github.com/ipfs/go-ipfs/pull/8183 (scheduled to ship in go-ipfs 0.11.0)
  - https://github.com/ipfs/js-ipfs/pull/3922  (tbd)