### PR TITLE
fix: use new go-ipfs sharding option

### DIFF
--- a/test/files.js
+++ b/test/files.js
@@ -18,9 +18,9 @@ class ExpectedError extends Error {
 const goOptions = {
   ipfsOptions: {
     config: {
-      // enabled sharding for go
-      Experimental: {
-        ShardingEnabled: true
+      // enabled sharding for go with automatic threshold dropped to the minimum
+      Internal: {
+        UnixFSShardingSizeThreshold: "1B"
       }
     }
   }


### PR DESCRIPTION
This will lower the threshold to the minimum for compatibility with existing tests as an alternative to #382 while https://github.com/ipfs/js-ipfs/issues/3921 is being investigated