### PR TITLE
feat: scripts/custom-runtime.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,25 @@ on:
     branches:
       - master
 
+# To run CI against unrelased go-ipfs or js-ipfs-* code (eg. wip PR),
+# uncomment env below and define git revisions in ./scripts/custom-runtime.sh
+
+#env:
+  #IPFS_GO_EXEC: /tmp/go-ipfs/cmd/ipfs/ipfs
+  #IPFS_JS_EXEC: /tmp/js-ipfs/packages/ipfs/src/cli.js
+  #IPFS_JS_MODULE: /tmp/js-ipfs/packages/ipfs/dist/cjs/src/index.js
+  #IPFS_JS_HTTP_MODULE: /tmp/js-ipfs/packages/ipfs-http-client/dist/cjs/src/index.js
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - uses: actions/setup-node@v2
         with:
           node-version: 16
       - uses: actions/cache@v2
@@ -18,12 +30,14 @@ jobs:
           CACHE_NAME: cache-node-modules
         with:
           path: |
+            /tmp/*-ipfs/**
             ~/.npm
             ./node_modules
           key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
       - name: Install Dependencies
         run: |
             npm install
+            ./scripts/custom-runtime.sh
             npm run build
 
   check:
@@ -41,6 +55,7 @@ jobs:
           CACHE_NAME: cache-node-modules
         with:
           path: |
+            /tmp/*-ipfs/**
             ~/.npm
             ./node_modules
           key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
@@ -59,7 +74,7 @@ jobs:
     name: test node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 16
       - uses: actions/cache@v2
@@ -68,6 +83,7 @@ jobs:
           CACHE_NAME: cache-node-modules
         with:
           path: |
+            /tmp/*-ipfs/**
             ~/.npm
             ./node_modules
           key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
@@ -92,7 +108,7 @@ jobs:
           - webworker
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 16
       - uses: actions/cache@v2
@@ -101,6 +117,7 @@ jobs:
           CACHE_NAME: cache-node-modules
         with:
           path: |
+            /tmp/*-ipfs/**
             ~/.npm
             ./node_modules
           key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
@@ -122,7 +139,7 @@ jobs:
           - electron-renderer
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 16
       - uses: actions/cache@v2
@@ -131,6 +148,7 @@ jobs:
           CACHE_NAME: cache-node-modules
         with:
           path: |
+            /tmp/*-ipfs/**
             ~/.npm
             ./node_modules
           key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ $ npm install -g ipfs-interop
 $ IPFS_GO_EXEC=/path IPFS_JS_EXEC=/path IPFS_JS_MODULE=/path IPFS_JS_HTTP_MODULE=/path ipfs-interop
 ```
 
+### As a custom runtime
+
+If you want to run interop on CI against specific repo and git revision of
+go-ipfs or js-ipfs* then set everything up in `./scripts/custom-runtime.sh`
+and enable it by uncommenting `env:` `IPFS_(..)` definitions in `.github/workflows/test.yml`
+
+If you want to test against unrelased things locally, make sure the same env
+variables are set on your machine.
+
+For example, to run pubsub tests against go-ipfs and js-ipfs revision defined
+in `./scripts/custom-runtime.sh`, one can:
+
+```
+export IPFS_GO_EXEC=/tmp/go-ipfs/cmd/ipfs/ipfs
+export IPFS_JS_EXEC=/tmp/js-ipfs/packages/ipfs/src/cli.js
+export IPFS_JS_MODULE=/tmp/js-ipfs/packages/ipfs/dist/cjs/src/index.js
+export IPFS_JS_HTTP_MODULE=/tmp/js-ipfs/packages/ipfs-http-client/dist/cjs/src/index.js
+./scripts/custom-runtime.sh
+node bin/ipfs-interop.js -- -t node --grep "pubsub"
+```
+
 ## Releasing a new version
 
 This repo does not use aegir for releases.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ipfs-interop": "bin/ipfs-interop.js"
   },
   "engines": {
-    "node": ">=12.0.0",
+    "node": ">=16.0.0",
     "npm": ">6.0.0"
   },
   "scripts": {

--- a/scripts/custom-runtime.sh
+++ b/scripts/custom-runtime.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# This script  sets up the Rube Goldberg machine for testing against custom
+# revision of go-ipfs and js-ipfs (the latter being tricky due to lerna monorepo)
+#
+# It assumes IPFS_GO_EXEC or IPFS_JS_EXEC to be in env.
+# One can trigger this locally by exporting the same path as we do on CI.
+# For example, to run pubsub tests against go-ipfs and js-ipfs revision defined
+# in ./scripts/custom-runtime.sh one can:
+#
+#  export IPFS_GO_EXEC=/tmp/go-ipfs/cmd/ipfs/ipfs
+#  export IPFS_JS_EXEC=/tmp/js-ipfs/packages/ipfs/src/cli.js
+#  export IPFS_JS_MODULE=/tmp/js-ipfs/packages/ipfs/dist/cjs/src/index.js
+#  export IPFS_JS_HTTP_MODULE=/tmp/js-ipfs/packages/ipfs-http-client/dist/cjs/src/index.js
+#  ./scripts/custom-runtime.sh
+#  node bin/ipfs-interop.js -- -t node --grep "pubsub"
+
+set -eo pipefail
+
+WORKDIR=$(pwd)
+
+if [ "$IPFS_GO_EXEC" == /tmp/go-ipfs/cmd/ipfs/ipfs ]; then
+if [ ! -d /tmp/go-ipfs ]; then
+    cd /tmp
+        git clone https://github.com/ipfs/go-ipfs.git
+        cd go-ipfs
+            # set implementation to specific commit
+            git checkout CHANGEME_GO
+            make build
+fi
+fi
+
+if [ "$IPFS_JS_EXEC" == /tmp/js-ipfs/packages/ipfs/src/cli.js ]; then
+if [ ! -d /tmp/js-ipfs ]; then
+    cd /tmp
+        git clone https://github.com/ipfs/js-ipfs.git
+        cd js-ipfs
+            # set implementation to specific commit
+            git checkout CHANGEME_JS
+            npm install
+            npm run build
+            npm run link
+fi
+fi
+
+cd $WORKDIR
+
+
+# print overrides
+env | grep IPFS_ || true


### PR DESCRIPTION
This PR extracts the glue code from #387  that simplifies running interop against unreleased code of go-ipfs and js-ipfs packages from lerna monorepo.

Goal here is to make it easier to land changes by demonstrating green CI and/or speed up local dev.

## DEMO

See  it in action in #387 where it takes care of running against specific git revisions of go-ipfs, js-ipfs(-http-server) and js-ipfs-http-client :robot: 

(next) I am going to use this for unblocking libp2p as well.