### PR TITLE
chore: restore ci tests on default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Rationale: 

- we finished landing and releasing all the breaking changes around go-ipfs 0.10 and 0.11, and switched to stable release versions of js-ipfs and go-ipfs 
- running on master  here will make it easie for us to determine if interop failures in js-ipfs/go-ipfs CI is upstream issue, or local.

Closes #409