### PR TITLE
fix: disable js dht during circuit tests

### DIFF
--- a/test/circuit/v1/browser.js
+++ b/test/circuit/v1/browser.js
@@ -151,7 +151,7 @@ export default {
     ]),
     connect: async (nodeA, nodeB, relay) => {
       await relay.api.swarm.connect(await getWrtcStarAddr(nodeA.api))
-      await relay.api.swarm.connect(getWsAddr(nodeB.api))
+      await relay.api.swarm.connect(await getWsAddr(nodeB.api))
       // TODO: needed until https://github.com/ipfs/interop/issues/17 is resolved
       await delay(3000)
       const nodeBCircuitAddr = `${await getWrtcStarAddr(relay.api)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`

--- a/test/circuit/v1/browser.js
+++ b/test/circuit/v1/browser.js
@@ -102,11 +102,11 @@ export default {
       createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-webrtc-star'], factory)
     ]),
     connect: async (nodeA, nodeB, relay) => {
-      await relay.api.swarm.connect(getWsAddr(nodeA.api.peerId.addresses))
-      await relay.api.swarm.connect(getWrtcStarAddr(nodeB.api.peerId.addresses))
+      await relay.api.swarm.connect(await getWsAddr(nodeA.api))
+      await relay.api.swarm.connect(await getWrtcStarAddr(nodeB.api))
       // TODO: needed until https://github.com/ipfs/interop/issues/17 is resolved
       await delay(5000)
-      const nodeBCircuitAddr = `${getWrtcStarAddr(relay.api.peerId.addresses)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
+      const nodeBCircuitAddr = `${await getWrtcStarAddr(relay.api)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
       await nodeA.api.swarm.connect(nodeBCircuitAddr)
     },
     skip: () => true // go-ipfs does not know what p2p-webrtc-star is
@@ -118,11 +118,11 @@ export default {
       createProc(['/ip4/127.0.0.1/tcp/24642/ws/p2p-webrtc-star'], factory)
     ]),
     connect: async (nodeA, nodeB, relay) => {
-      await relay.api.swarm.connect(getWsAddr(nodeA.api.peerId.addresses))
-      await relay.api.swarm.connect(getWrtcStarAddr(nodeB.api.peerId.addresses))
+      await relay.api.swarm.connect(await getWsAddr(nodeA.api))
+      await relay.api.swarm.connect(await getWrtcStarAddr(nodeB.api))
       // TODO: needed until https://github.com/ipfs/interop/issues/17 is resolved
       await delay(3000)
-      const nodeBCircuitAddr = `${getWrtcStarAddr(relay.api.peerId.addresses)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
+      const nodeBCircuitAddr = `${await getWrtcStarAddr(relay.api)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
       await nodeA.api.swarm.connect(nodeBCircuitAddr)
     },
     skip: () => isWebWorker // no webrtc support in webworkers
@@ -134,11 +134,11 @@ export default {
       createGo([randomWsAddr], factory)
     ]),
     connect: async (nodeA, nodeB, relay) => {
-      await relay.api.swarm.connect(getWrtcStarAddr(nodeA.api.peerId.addresses))
-      await relay.api.swarm.connect(getWsAddr(nodeB.api.peerId.addresses))
+      await relay.api.swarm.connect(await getWrtcStarAddr(nodeA.api))
+      await relay.api.swarm.connect(await getWsAddr(nodeB.api))
       // TODO: needed until https://github.com/ipfs/interop/issues/17 is resolved
       await delay(5000)
-      const nodeBCircuitAddr = `${getWrtcStarAddr(relay.api.peerId.addresses)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
+      const nodeBCircuitAddr = `${await getWrtcStarAddr(relay.api)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
       await nodeA.api.swarm.connect(nodeBCircuitAddr)
     },
     skip: () => isWebWorker // no webrtc support in webworkers
@@ -150,11 +150,11 @@ export default {
       createJs([randomWsAddr], factory)
     ]),
     connect: async (nodeA, nodeB, relay) => {
-      await relay.api.swarm.connect(getWrtcStarAddr(nodeA.api.peerId.addresses))
-      await relay.api.swarm.connect(getWsAddr(nodeB.api.peerId.addresses))
+      await relay.api.swarm.connect(await getWrtcStarAddr(nodeA.api))
+      await relay.api.swarm.connect(getWsAddr(nodeB.api))
       // TODO: needed until https://github.com/ipfs/interop/issues/17 is resolved
       await delay(3000)
-      const nodeBCircuitAddr = `${getWrtcStarAddr(relay.api.peerId.addresses)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
+      const nodeBCircuitAddr = `${await getWrtcStarAddr(relay.api)}/p2p-circuit/p2p/${nodeB.api.peerId.id}`
       await nodeA.api.swarm.connect(nodeBCircuitAddr)
     },
     skip: () => isWebWorker // no webrtc support in webworkers

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -175,7 +175,7 @@ export function getWsAddr (addrs) {
     })
 
   if (!result) {
-    throw new Error('No ws address found in ' + addrs)
+    throw new Error(`No ws address found in ${addrs}`)
   }
 
   return result
@@ -187,7 +187,7 @@ export function getWsStarAddr (addrs) {
     .find((a) => a.includes('/p2p-websocket-star'))
 
   if (!result) {
-    throw new Error('No wsstar address found in ' + addrs)
+    throw new Error(`No wsstar address found in ${addrs}`)
   }
 
   return result
@@ -199,7 +199,7 @@ export function getWrtcStarAddr (addrs) {
     .find((a) => a.includes('/p2p-webrtc-star'))
 
   if (!result) {
-    throw new Error('No webrtcstar address found in ' + addrs)
+    throw new Error(`No webrtcstar address found in ${addrs}`)
   }
 
   return result
@@ -211,7 +211,7 @@ export function getTcpAddr (addrs) {
     .find((a) => !a.includes('/ws') && !a.includes('/p2p-websocket-star'))
 
   if (!result) {
-    throw new Error('No TCP address found in ' + addrs)
+    throw new Error(`No TCP address found in ${addrs}`)
   }
 
   return result

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -21,6 +21,9 @@ export function createProc (addrs, factory, relay) {
         Addresses: {
           Swarm: addrs
         },
+        Routing: {
+          Type: 'none'
+        },
         relay: { // FIXME: this is circuit v1, needs support of v2
           enabled: true,
           hop: {
@@ -34,6 +37,9 @@ export function createProc (addrs, factory, relay) {
             [transportKey]: {
               filter: filters.all
             }
+          },
+          dht: {
+            enabled: false
           }
         }
       }
@@ -52,10 +58,20 @@ export function createJs (addrs, factory, relay) {
         Addresses: {
           Swarm: addrs
         },
+        Routing: {
+          Type: 'none'
+        },
         relay: { // FIXME: this is circuit v1, needs support of v2
           enabled: true,
           hop: {
             enabled: true
+          }
+        },
+        libp2p: {
+          config: {
+            dht: {
+              enabled: false
+            }
           }
         }
       }

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -3,6 +3,7 @@ import delay from 'delay'
 import randomBytes from 'iso-random-stream/src/random.js'
 import concat from 'it-concat'
 import WS from 'libp2p-websockets'
+import pRetry from 'p-retry'
 import filters from 'libp2p-websockets/src/filters.js'
 import { expect } from 'aegir/utils/chai.js'
 
@@ -168,61 +169,69 @@ export async function send (nodeA, nodeB) {
 }
 
 export async function getWsAddr (api) {
-  const id = await api.id()
+  return await pRetry(async () => {
+    const id = await api.id()
 
-  const result = id.addresses
-    .map((a) => a.toString())
-    .find((a) => {
-      return a.includes('/ws') && !a.includes('/p2p-websocket-star')
-    })
+    const result = id.addresses
+      .map((a) => a.toString())
+      .find((a) => {
+        return a.includes('/ws') && !a.includes('/p2p-websocket-star')
+      })
 
-  if (!result) {
-    throw new Error(`No ws address found in ${id.addresses}`)
-  }
+    if (!result) {
+      throw new Error(`No ws address found in ${id.addresses}`)
+    }
 
-  return result
+    return result
+  })
 }
 
 export async function getWsStarAddr (api) {
-  const id = await api.id()
+  return await pRetry(async () => {
+    const id = await api.id()
 
-  const result = id.addresses
-    .map((a) => a.toString())
-    .find((a) => a.includes('/p2p-websocket-star'))
+    const result = id.addresses
+      .map((a) => a.toString())
+      .find((a) => a.includes('/p2p-websocket-star'))
 
-  if (!result) {
-    throw new Error(`No wsstar address found in ${id.addresses}`)
-  }
+    if (!result) {
+      throw new Error(`No wsstar address found in ${id.addresses}`)
+    }
 
-  return result
+    return result
+  })
 }
 
 export async function getWrtcStarAddr (api) {
-  const id = await api.id()
+  return await pRetry(async () => {
+    const id = await api.id()
 
-  const result = id.addresses
-    .map((a) => a.toString())
-    .find((a) => a.includes('/p2p-webrtc-star'))
+    const result = id.addresses
+      .map((a) => a.toString())
+      .find((a) => a.includes('/p2p-webrtc-star'))
 
-  if (!result) {
-    throw new Error(`No webrtcstar address found in ${id.addresses}`)
+    if (!result) {
+      throw new Error(`No webrtcstar address found in ${id.addresses}`)
+    }
+
+    return result
   }
-
-  return result
 }
 
 export async function getTcpAddr (api) {
-  const id = await api.id()
+  return await pRetry(async () => {
+    const id = await api.id()
 
-  const result = id.addresses
-    .map((a) => a.toString())
-    .find((a) => !a.includes('/ws') && !a.includes('/p2p-websocket-star'))
+    const result = id.addresses
+      .map((a) => a.toString())
+      .find((a) => !a.includes('/ws') && !a.includes('/p2p-websocket-star'))
 
-  if (!result) {
-    throw new Error(`No TCP address found in ${id.addresses}`)
-  }
+    if (!result) {
+      throw new Error(`No TCP address found in ${id.addresses}`)
+    }
 
-  return result
+    return result
+  })
 }
 
 export async function connect (nodeA, nodeB, relay, timeout = 1000) {

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -235,7 +235,7 @@ export async function getTcpAddr (api) {
 }
 
 export async function connect (nodeA, nodeB, relay, timeout = 1000) {
-  const relayWsAddr = await getWsAddr(relay.api.peerId.addresses)
+  const relayWsAddr = await getWsAddr(relay.api)
   const nodeAId = nodeA.api.peerId.id
   const nodeBId = nodeB.api.peerId.id
 

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -215,7 +215,7 @@ export async function getWrtcStarAddr (api) {
     }
 
     return result
-  }
+  })
 }
 
 export async function getTcpAddr (api) {

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -80,10 +80,10 @@ export function createJs (addrs, factory, relay) {
 }
 
 // creates "private" go-ipfs node which is uses static relay if specified
-export function createGo (addrs, factory, relay) {
+export async function createGo (addrs, factory, relay) {
   let StaticRelays
   if (relay) {
-    StaticRelays = [getWsAddr(relay.api.peerId.addresses)]
+    StaticRelays = [await getWsAddr(relay.api)]
   }
   return factory.spawn({
     type: 'go',
@@ -167,58 +167,66 @@ export async function send (nodeA, nodeB) {
   expect(buffer.slice()).to.deep.equal(data)
 }
 
-export function getWsAddr (addrs) {
-  const result = addrs
+export async function getWsAddr (api) {
+  const id = await api.id()
+
+  const result = id.addresses
     .map((a) => a.toString())
     .find((a) => {
       return a.includes('/ws') && !a.includes('/p2p-websocket-star')
     })
 
   if (!result) {
-    throw new Error(`No ws address found in ${addrs}`)
+    throw new Error(`No ws address found in ${id.addresses}`)
   }
 
   return result
 }
 
-export function getWsStarAddr (addrs) {
-  const result = addrs
+export async function getWsStarAddr (api) {
+  const id = await api.id()
+
+  const result = id.addresses
     .map((a) => a.toString())
     .find((a) => a.includes('/p2p-websocket-star'))
 
   if (!result) {
-    throw new Error(`No wsstar address found in ${addrs}`)
+    throw new Error(`No wsstar address found in ${id.addresses}`)
   }
 
   return result
 }
 
-export function getWrtcStarAddr (addrs) {
-  const result = addrs
+export async function getWrtcStarAddr (api) {
+  const id = await api.id()
+
+  const result = id.addresses
     .map((a) => a.toString())
     .find((a) => a.includes('/p2p-webrtc-star'))
 
   if (!result) {
-    throw new Error(`No webrtcstar address found in ${addrs}`)
+    throw new Error(`No webrtcstar address found in ${id.addresses}`)
   }
 
   return result
 }
 
-export function getTcpAddr (addrs) {
-  const result = addrs
+export async function getTcpAddr (api) {
+  const id = await api.id()
+
+  const result = id.addresses
     .map((a) => a.toString())
     .find((a) => !a.includes('/ws') && !a.includes('/p2p-websocket-star'))
 
   if (!result) {
-    throw new Error(`No TCP address found in ${addrs}`)
+    throw new Error(`No TCP address found in ${id.addresses}`)
   }
 
   return result
 }
 
 export async function connect (nodeA, nodeB, relay, timeout = 1000) {
-  const relayWsAddr = getWsAddr(relay.api.peerId.addresses)
+  const relayWsAddr = await getWsAddr(relay.api.peerId.addresses)
   const nodeAId = nodeA.api.peerId.id
   const nodeBId = nodeB.api.peerId.id
 

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -168,8 +168,8 @@ export async function send (nodeA, nodeB) {
 }
 
 export function getWsAddr (addrs) {
-  addrs = addrs.map((a) => a.toString())
   const result = addrs
+    .map((a) => a.toString())
     .find((a) => {
       return a.includes('/ws') && !a.includes('/p2p-websocket-star')
     })
@@ -182,8 +182,8 @@ export function getWsAddr (addrs) {
 }
 
 export function getWsStarAddr (addrs) {
-  addrs = addrs.map((a) => a.toString())
   const result = addrs
+    .map((a) => a.toString())
     .find((a) => a.includes('/p2p-websocket-star'))
 
   if (!result) {
@@ -194,8 +194,8 @@ export function getWsStarAddr (addrs) {
 }
 
 export function getWrtcStarAddr (addrs) {
-  addrs = addrs.map((a) => a.toString())
   const result = addrs
+    .map((a) => a.toString())
     .find((a) => a.includes('/p2p-webrtc-star'))
 
   if (!result) {
@@ -206,8 +206,8 @@ export function getWrtcStarAddr (addrs) {
 }
 
 export function getTcpAddr (addrs) {
-  addrs = addrs.map((a) => a.toString())
   const result = addrs
+    .map((a) => a.toString())
     .find((a) => !a.includes('/ws') && !a.includes('/p2p-websocket-star'))
 
   if (!result) {

--- a/test/utils/relayd.js
+++ b/test/utils/relayd.js
@@ -3,7 +3,6 @@ import fs from 'fs'
 import path from 'path'
 import { command } from 'execa'
 import goenv from 'go-platform'
-import { MultiAddr } from 'multiaddr'
 const platform = process.env.TARGET_OS || goenv.GOOS
 
 // augumentWithRelayd is the glue code that makes running relayd-based relay

--- a/test/utils/relayd.js
+++ b/test/utils/relayd.js
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import { command } from 'execa'
 import goenv from 'go-platform'
+import { MultiAddr } from 'multiaddr'
 const platform = process.env.TARGET_OS || goenv.GOOS
 
 // augumentWithRelayd is the glue code that makes running relayd-based relay
@@ -38,7 +39,13 @@ export async function getRelayV (version, factory) {
         addresses: [
           `${config.Network.ListenAddrs[0]}/p2p/${id}`
         ]
-      }
+      },
+      id: () => Promise.resolve({
+        id,
+        addresses: [
+          `${config.Network.ListenAddrs[0]}/p2p/${id}`
+        ]
+      })
     }
   }
   relays.set(version, result)


### PR DESCRIPTION
There aren't enough peers to use the DHT during circuit tests, so disable it for JS the same way it's disabled for Go.