### PR TITLE
fix: when hole punching is enabled by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "ipfs-interop": "bin/ipfs-interop.js"
       },
       "devDependencies": {
-        "go-ipfs": "^0.11.0",
+        "go-ipfs": "^0.12.2",
         "ipfs": "^0.61.0",
         "ipfs-http-client": "^55.0.0"
       },
@@ -9136,13 +9136,13 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.11.0",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.12.2.tgz",
+      "integrity": "sha512-4eA4xFRDM1JfC3W+IkAk2VUauVWKp3zHghiXCs+8SizhNrfajTwzhLduFNnQtjLYicXlhfX1Hjm8uk011ypV6Q==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "cachedir": "^2.3.0",
-        "go-platform": "^1.0.0",
         "got": "^11.7.0",
         "gunzip-maybe": "^1.4.2",
         "hasha": "^5.2.2",
@@ -28939,11 +28939,12 @@
       }
     },
     "go-ipfs": {
-      "version": "0.11.0",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.12.2.tgz",
+      "integrity": "sha512-4eA4xFRDM1JfC3W+IkAk2VUauVWKp3zHghiXCs+8SizhNrfajTwzhLduFNnQtjLYicXlhfX1Hjm8uk011ypV6Q==",
       "dev": true,
       "requires": {
         "cachedir": "^2.3.0",
-        "go-platform": "^1.0.0",
         "got": "^11.7.0",
         "gunzip-maybe": "^1.4.2",
         "hasha": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "wherearewe": "^1.0.0"
   },
   "devDependencies": {
-    "go-ipfs": "^0.11.0",
+    "go-ipfs": "^0.12.2",
     "ipfs": "^0.61.0",
     "ipfs-http-client": "^55.0.0"
   },

--- a/scripts/setup-libp2p-relay-daemon.js
+++ b/scripts/setup-libp2p-relay-daemon.js
@@ -81,7 +81,7 @@ async function getDownloadURL (version, platform, arch, distUrl) {
   }
 
   if (!data.platforms[platform].archs[arch]) {
-    throw new Error(`No binary available for arch '${arch}'`)
+    throw new Error(`No binary available for platform '${platform}' and arch '${arch}'`)
   }
 
   const link = data.platforms[platform].archs[arch].link

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -94,6 +94,7 @@ export async function createGo (addrs, factory, relay) {
           Swarm: addrs
         },
         Swarm: {
+          EnableHolePunching: false,
           // go uses circuit v2
           RelayClient: {
             Enabled: true,
@@ -130,6 +131,7 @@ export function createGoRelay (addrs, factory) {
           Swarm: addrs
         },
         Swarm: {
+          EnableHolePunching: false,
           // go uses circuit v2
           RelayClient: {
             Enabled: false


### PR DESCRIPTION
This fixes interop tests when Swarm.EnableHolePunching in go-ipfs is
enabled by default.

Ref. https://github.com/ipfs/go-ipfs/pull/8748