### PR TITLE
chore(deps): bump aegir from 36.1.3 to 36.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "aegir": "^36.1.3",
+        "aegir": "^36.2.3",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "cachedir": "^2.3.0",
@@ -1930,14 +1930,16 @@
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
       "dependencies": {
         "debug": "^4.1.1"
       }
     },
     "node_modules/@kwsites/promise-deferred": {
       "version": "1.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.3",
@@ -2972,8 +2974,9 @@
       "license": "MIT"
     },
     "node_modules/aegir": {
-      "version": "36.1.3",
-      "license": "MIT",
+      "version": "36.2.3",
+      "resolved": "https://registry.npmjs.org/aegir/-/aegir-36.2.3.tgz",
+      "integrity": "sha512-8xBfUxXK9/jlq4Yj1pVP5Va1nN2L7vE//q02lZ/+VsF0EMjB4oT5n2dpyKxd658FV7kmmstLp8TRg/W/OvIbYg==",
       "dependencies": {
         "@electron/get": "^1.12.3",
         "@polka/send-type": "^0.5.2",
@@ -2993,7 +2996,6 @@
         "buffer": "^6.0.3",
         "bytes": "^3.1.0",
         "c8": "^7.7.0",
-        "camelcase": "^6.2.0",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "chai-bites": "^0.1.2",
@@ -3034,6 +3036,7 @@
         "ora": "^5.4.0",
         "p-map": "4.0.0",
         "pascalcase": "^1.0.0",
+        "path": "^0.12.7",
         "playwright-test": "^7.0.2",
         "polka": "^0.5.2",
         "premove": "^3.0.1",
@@ -3043,7 +3046,7 @@
         "semantic-release": "^18.0.1",
         "semantic-release-monorepo": "^7.0.5",
         "semver": "^7.3.5",
-        "simple-git": "^2.37.0",
+        "simple-git": "^3.3.0",
         "source-map-support": "^0.5.20",
         "strip-bom": "4.0.0",
         "strip-json-comments": "^3.1.1",
@@ -3054,11 +3057,11 @@
         "yargs": "^17.1.1"
       },
       "bin": {
-        "aegir": "cli.js"
+        "aegir": "src/index.js"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -18053,6 +18056,15 @@
         "which": "bin/which"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "license": "MIT"
@@ -18096,6 +18108,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "node_modules/path/node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
       }
     },
     "node_modules/pathval": {
@@ -20961,12 +20986,13 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "2.48.0",
-      "license": "MIT",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.4.0.tgz",
+      "integrity": "sha512-sBRdudUc1yvi0xQQPuHXc1L9gTWkRn4hP2bbc7q4BTxR502d3JJAGsDOhrmsBY+wAZAw5JLl82tx55fSWYE65w==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       },
       "funding": {
         "type": "github",
@@ -24194,12 +24220,16 @@
     },
     "@kwsites/file-exists": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
       "requires": {
         "debug": "^4.1.1"
       }
     },
     "@kwsites/promise-deferred": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.3",
@@ -24913,7 +24943,9 @@
       "version": "1.0.0"
     },
     "aegir": {
-      "version": "36.1.3",
+      "version": "36.2.3",
+      "resolved": "https://registry.npmjs.org/aegir/-/aegir-36.2.3.tgz",
+      "integrity": "sha512-8xBfUxXK9/jlq4Yj1pVP5Va1nN2L7vE//q02lZ/+VsF0EMjB4oT5n2dpyKxd658FV7kmmstLp8TRg/W/OvIbYg==",
       "requires": {
         "@electron/get": "^1.12.3",
         "@polka/send-type": "^0.5.2",
@@ -24933,7 +24965,6 @@
         "buffer": "^6.0.3",
         "bytes": "^3.1.0",
         "c8": "^7.7.0",
-        "camelcase": "^6.2.0",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "chai-bites": "^0.1.2",
@@ -24974,6 +25005,7 @@
         "ora": "^5.4.0",
         "p-map": "4.0.0",
         "pascalcase": "^1.0.0",
+        "path": "^0.12.7",
         "playwright-test": "^7.0.2",
         "polka": "^0.5.2",
         "premove": "^3.0.1",
@@ -24983,7 +25015,7 @@
         "semantic-release": "^18.0.1",
         "semantic-release-monorepo": "^7.0.5",
         "semver": "^7.3.5",
-        "simple-git": "^2.37.0",
+        "simple-git": "^3.3.0",
         "source-map-support": "^0.5.20",
         "strip-bom": "4.0.0",
         "strip-json-comments": "^3.1.1",
@@ -34960,6 +34992,30 @@
         }
       }
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "util": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        }
+      }
+    },
     "path-browserify": {
       "version": "1.0.1"
     },
@@ -36784,11 +36840,13 @@
       }
     },
     "simple-git": {
-      "version": "2.48.0",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.4.0.tgz",
+      "integrity": "sha512-sBRdudUc1yvi0xQQPuHXc1L9gTWkRn4hP2bbc7q4BTxR502d3JJAGsDOhrmsBY+wAZAw5JLl82tx55fSWYE65w==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       }
     },
     "single-line-log": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "dep-check": "aegir dep-check package.json"
   },
   "dependencies": {
-    "aegir": "^36.1.3",
+    "aegir": "^36.2.3",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
     "cachedir": "^2.3.0",


### PR DESCRIPTION
This is a follow up to https://github.com/ipfs/aegir/pull/944.

I bumped the version and ran `npm install`.