### PR TITLE
fix: add fs and go-ipfs to browser ignores

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "scripts": {
     "clean": "rimraf /tmp/js-ipfs /tmp/go-ipfs ./go-libp2p-relay-daemon dist types",
     "lint": "aegir lint",
-    "build": "aegir build --esm-tests && cp -R types scripts bin test src .aegir.cjs dist && cp bin/package.json dist/src && cp bin/package.json dist/test && npx json -I -f dist/package.json -e 'this.browser.execa=false'",
+    "build": "aegir build --esm-tests && cp -R types scripts bin test src .aegir.cjs dist && cp bin/package.json dist/src && cp bin/package.json dist/test && npx json -I -f dist/package.json -e 'this.browser.execa=false; this.browser.fs=false; this.browser[\"go-ipfs\"]=false'",
     "release": "semantic-release",
     "postinstall": "cross-env node ./scripts/setup-libp2p-relay-daemon.js",
     "pretest": "aegir build --esm-tests",


### PR DESCRIPTION
We add execa to the browser ignores but we need to add fs and go-ipfs as well.

We can revert this once we drop CJS support since we're changing the package.json generated by ipjs and with just ESM we won't need ipjs any more.