### PR TITLE
feat: enable relay v2 tests for js-ipfs

### DIFF
--- a/test/circuit/v1/all.js
+++ b/test/circuit/v1/all.js
@@ -67,55 +67,5 @@ export default {
         createJs([randomWsAddr], factory)
       ])
     }
-  },
-
-  // Below are legacy tests that use js-ipfs as v1 relay
-  // (no tests for go-ipfs as relay v1, because since 0.11 it only supports v2)
-  // FIXME: remove after js-ipfs migrates to v2
-
-  'go-js-go': {
-    /**
-     * @param {Factory} factory
-     */
-    create: async (factory) => {
-      return Promise.all([
-        createGo([randomWsAddr], factory),
-        createJs([randomWsAddr], factory),
-        createGo([randomWsAddr], factory)
-      ])
-    }
-  },
-  'js-js-go': {
-    /**
-     * @param {Factory} factory
-     */
-    create: async (factory) => {
-      return Promise.all([
-        createJs([randomWsAddr], factory),
-        createJs([randomWsAddr], factory),
-        createGo([randomWsAddr], factory)
-      ])
-    }
-  },
-  'go-js-js': {
-    /**
-     * @param {Factory} factory
-     */
-    create: (factory) => Promise.all([
-      createGo([randomWsAddr], factory),
-      createJs([randomWsAddr], factory),
-      createJs([randomWsAddr], factory)
-    ])
-  },
-  'js-js-js': {
-    /**
-     * @param {Factory} factory
-     */
-    create: (factory) => Promise.all([
-      createJs([randomWsAddr], factory),
-      createJs([randomWsAddr], factory),
-      createJs([randomWsAddr], factory)
-    ])
   }
-
 }

--- a/test/circuit/v2/all.js
+++ b/test/circuit/v2/all.js
@@ -1,7 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
 
-import { createGo, createGoRelay, randomWsAddr } from '../../utils/circuit.js'
+import { createGo, createJs, createGoRelay, createJsRelay, randomWsAddr } from '../../utils/circuit.js'
 import { getRelayV } from '../../utils/relayd.js'
 
 /**
@@ -28,15 +28,45 @@ export default {
   },
 
   'js-rv2-js': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await getRelayV(2)
+      return Promise.all([
+        createJs([randomWsAddr], factory),
+        relay,
+        createJs([randomWsAddr], factory, relay)
+      ])
+    }
   },
 
   'js-rv2-go': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await getRelayV(2)
+      return Promise.all([
+        createJs([randomWsAddr], factory),
+        relay,
+        createGo([randomWsAddr], factory, relay)
+      ])
+    }
   },
 
   'go-rv2-js': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await getRelayV(2)
+      return Promise.all([
+        createGo([randomWsAddr], factory),
+        relay,
+        createJs([randomWsAddr], factory, relay)
+      ])
+    }
   },
 
   // relay v2 implementation in go-ipfs 0.11+
@@ -55,28 +85,97 @@ export default {
     }
   },
   'js-go-go': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await createGoRelay([randomWsAddr], factory)
+      return Promise.all([
+        createJs([randomWsAddr], factory),
+        relay,
+        createGo([randomWsAddr], factory, relay)
+      ])
+    }
   },
   'go-go-js': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await createGoRelay([randomWsAddr], factory)
+      return Promise.all([
+        createGo([randomWsAddr], factory),
+        relay,
+        createJs([randomWsAddr], factory, relay)
+      ])
+    }
   },
   'js-go-js': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await createGoRelay([randomWsAddr], factory)
+      return Promise.all([
+        createJs([randomWsAddr], factory),
+        relay,
+        createJs([randomWsAddr], factory, relay)
+      ])
+    }
   },
 
   // relay v2 implementation in js-ipfs
 
   'go-js-go': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await createJsRelay([randomWsAddr], factory)
+      return Promise.all([
+        createGo([randomWsAddr], factory),
+        relay,
+        createGo([randomWsAddr], factory, relay)
+      ])
+    }
   },
   'js-js-go': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await createJsRelay([randomWsAddr], factory)
+      return Promise.all([
+        createJs([randomWsAddr], factory),
+        relay,
+        createGo([randomWsAddr], factory, relay)
+      ])
+    }
   },
   'go-js-js': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await createJsRelay([randomWsAddr], factory)
+      return Promise.all([
+        createGo([randomWsAddr], factory),
+        relay,
+        createJs([randomWsAddr], factory, relay)
+      ])
+    }
   },
   'js-js-js': {
-    skip: () => true // FIXME when we have circuit v2 in js-ipfs
+    /**
+     * @param {Factory} factory
+     */
+    create: async (factory) => {
+      const relay = await createJsRelay([randomWsAddr], factory)
+      return Promise.all([
+        createJs([randomWsAddr], factory),
+        relay,
+        createJs([randomWsAddr], factory, relay)
+      ])
+    }
   }
-
 }

--- a/test/utils/circuit.js
+++ b/test/utils/circuit.js
@@ -21,9 +21,10 @@ export const randomWsAddr = '/ip4/127.0.0.1/tcp/0/ws'
  * @param {Factory} factory
  * @param {Controller} [relay]
  */
-export function createProc (addrs, factory, relay) {
+export async function createProc (addrs, factory, relay) {
+  let StaticRelays
   if (relay) {
-    throw new Error('createProc missing support for static relay v2')
+    StaticRelays = [await getWsAddr(relay.api)]
   }
   return factory.spawn({
     type: 'proc',
@@ -32,14 +33,23 @@ export function createProc (addrs, factory, relay) {
         Addresses: {
           Swarm: addrs
         },
+        Swarm: {
+          RelayClient: {
+            Enabled: true,
+            StaticRelays
+          },
+          RelayService: {
+            Enabled: false
+          }
+        },
+        Bootstraps: [],
+        Discovery: {
+          MDNS: {
+            Enabled: false
+          }
+        },
         Routing: {
           Type: 'none'
-        },
-        relay: { // FIXME: this is circuit v1, needs support of v2
-          enabled: true,
-          hop: {
-            enabled: true
-          }
         }
       },
       libp2p: {
@@ -58,9 +68,10 @@ export function createProc (addrs, factory, relay) {
  * @param {Factory} factory
  * @param {Controller} [relay]
  */
-export function createJs (addrs, factory, relay) {
+export async function createJs (addrs, factory, relay) {
+  let StaticRelays
   if (relay) {
-    throw new Error('createJs missing support for static relay v2')
+    StaticRelays = [await getWsAddr(relay.api)]
   }
   return factory.spawn({
     type: 'js',
@@ -69,14 +80,58 @@ export function createJs (addrs, factory, relay) {
         Addresses: {
           Swarm: addrs
         },
+        Swarm: {
+          RelayClient: {
+            Enabled: true,
+            StaticRelays
+          },
+          RelayService: {
+            Enabled: false
+          }
+        },
+        Bootstraps: [],
+        Discovery: {
+          MDNS: {
+            Enabled: false
+          }
+        },
         Routing: {
           Type: 'none'
+        }
+      }
+    }
+  })
+}
+
+/**
+ * @param {string[]} addrs
+ * @param {Factory} factory
+ */
+export async function createJsRelay (addrs, factory) {
+  return factory.spawn({
+    type: 'js',
+    ipfsOptions: {
+      config: {
+        Addresses: {
+          Swarm: addrs
         },
-        relay: { // FIXME: this is circuit v1, needs support of v2
-          enabled: true,
-          hop: {
-            enabled: true
+        Swarm: {
+          // go uses circuit v2
+          RelayClient: {
+            Enabled: false
+          },
+          RelayService: {
+            Enabled: true
           }
+        },
+        Bootstraps: [],
+        Discovery: {
+          MDNS: {
+            Enabled: false
+          }
+        },
+        Routing: {
+          Type: 'none'
         }
       }
     }


### PR DESCRIPTION
Circuit Relay v2 is being implemented in https://github.com/libp2p/js-libp2p/pull/1533 - we should be able to add it with minimal changes to js-ipfs so enable the tests here to prove interop.